### PR TITLE
Added vue package

### DIFF
--- a/packages/quill-next-vue/.eslintrc.cjs
+++ b/packages/quill-next-vue/.eslintrc.cjs
@@ -1,0 +1,35 @@
+
+module.exports = {
+  root: true,
+  parser: '@typescript-eslint/parser',
+  ignorePatterns: [
+    "packages/blocky-common/src/hash.ts",
+    "*.js",
+    "*.d.ts"
+  ],
+  plugins: [
+    '@typescript-eslint',
+  ],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+  ],
+  rules: {
+    "@typescript-eslint/no-explicit-any": 0,
+    "@typescript-eslint/no-non-null-assertion": 0,
+    "@typescript-eslint/no-empty-function": 0,
+    "@typescript-eslint/no-this-alias": 0,
+    "@typescript-eslint/ban-ts-comment": 1,
+    "@typescript-eslint/no-unused-vars": 2,
+    "@typescript-eslint/explicit-function-return-type": "error",
+    "@typescript-eslint/explicit-member-accessibility": [2, {
+      accessibility: "no-public"
+    }],
+    'lines-between-class-members': [
+      'error',
+      'always',
+      { 'exceptAfterSingleLine': true },
+    ],
+    "no-empty": 1
+  },
+};

--- a/packages/quill-next-vue/.gitignore
+++ b/packages/quill-next-vue/.gitignore
@@ -1,0 +1,5 @@
+
+/dist
+/node_modules
+
+!.eslintrc.cjs

--- a/packages/quill-next-vue/README.md
+++ b/packages/quill-next-vue/README.md
@@ -1,0 +1,108 @@
+# Quill Next Vue
+
+A simple and flexible Vue component wrapper for the Quill Next.
+
+I plan to release a new version every 2 weeks with new features and improvements, so stay tuned!
+
+## Requirements
+
+This package requires Vue 3.4+ and Quill Next as peer dependencies. It is designed to work with the latest versions of both libraries.
+
+## Installation
+
+```bash
+npm install quill-next-vue
+# or
+yarn add quill-next-vue
+#or
+pnpm add quill-next-vue
+```
+
+You can install the package using npm or yarn:
+
+```bash
+npm install quill-next-vue
+# or
+yarn add quill-next-vue
+#or
+pnpm add quill-next-vue
+```
+
+**Note**: This package assumes that `quill-next` and `vue` (3.4+) are already installed. It also requires Quill as a peer dependency. You might need to install it separately if you haven't already:
+
+```bash
+npm install quill-next
+# or
+yarn add quill-next
+#or
+pnpm add quill-next
+```
+
+## Notice
+
+It is only the first version of the package, so it may not be fully functional and may contain bugs and instabilities. If you encounter any issues, please open an issue on the GitHub repository.
+
+It also suports only a subset of Quill Next features, so some advanced features may not work as expected or may not be implemented yet.
+
+But since I personally use it in my projects, I will try to fix bugs and add new features as soon as possible.
+
+As of version 1.0.0, it is only a wrapper and nothing more. Vue-specific optimizations and features will be added in future versions.
+
+## Usage
+
+Import the QuillEditor component and use it in your Vue application.
+
+```vue
+<template>
+	<quill-editor
+		v-model="editorContent"
+		@text-change="onTextChange"
+		@ready="onReady"
+		:config="editorConfig"
+	/>
+</template>
+
+<script>
+import { ref } from 'vue'
+import { Delta } from 'quill-next'
+import QuillEditor from 'quill-next-vue'
+
+export default {
+	components: {
+		QuillEditor,
+	},
+	setup() {
+		const editorContent = ref(new Delta().insert('Hello World!'))
+		const editorConfig = {
+			theme: 'snow',
+			modules: {
+				toolbar: [
+					[{ header: [1, 2, false] }],
+					['bold', 'italic', 'underline'],
+					['image', 'code-block'],
+				],
+			},
+		}
+
+		const onTextChange = () => {
+			// Handle text change
+		}
+
+		const onReady = () => {
+			// Handle editor ready
+		}
+
+		return {
+			editorContent,
+			editorConfig,
+			onTextChange,
+			onReady,
+		}
+	},
+}
+</script>
+```
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit issues or pull requests.

--- a/packages/quill-next-vue/dev/App.vue
+++ b/packages/quill-next-vue/dev/App.vue
@@ -1,0 +1,23 @@
+<template>
+	<QuillEditor v-model="value" />
+	<hr />
+	<pre>
+		{{ { value } }}
+	</pre
+	>
+	<button @click="onAdd('popa')">Add popa</button>
+</template>
+
+<script setup lang="ts">
+import QuillEditor from '../src/components/quill-editor.vue'
+import { ref } from 'vue'
+import { Delta } from 'quill-next'
+
+const value = ref<Delta>(new Delta().insert('Hello, Quill!'))
+
+function onAdd(text: string) {
+	value.value = value.value.insert(text)
+}
+</script>
+
+<style scoped></style>

--- a/packages/quill-next-vue/dev/index.html
+++ b/packages/quill-next-vue/dev/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<title>Dev Quill Vue</title>
+	</head>
+
+	<body>
+		<div id="app"></div>
+		<script
+			type="module"
+			src="/main.ts"
+		></script>
+	</body>
+</html>

--- a/packages/quill-next-vue/dev/main.ts
+++ b/packages/quill-next-vue/dev/main.ts
@@ -1,0 +1,5 @@
+import { createApp } from 'vue'
+import App from './App.vue'
+import 'quill-next/dist/quill.snow.css'
+
+createApp(App).mount('#app')

--- a/packages/quill-next-vue/package.json
+++ b/packages/quill-next-vue/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "quill-next-vue",
+  "version": "1.0.0",
+  "author": "Sannnekk <https://github.com/sannnekk>",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vincentdchan/quill-next",
+    "directory": "packages/quill-next-vue"
+  },
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "vite build && tsc",
+    "build:ts": "tsc",
+    "test:unit": "vitest",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix"
+  },
+  "license": "BSD-3-Clause",
+  "packageManager": "pnpm@10.12.1",
+  "dependencies": {
+    "lodash-es": "^4.17.21",
+    "vue": "^3.4.0",
+    "parchment": "*"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^5.0.0",
+    "@vue/compiler-sfc": "^3.4.0",
+    "eslint": "^8.0.0",
+    "eslint-plugin-vue": "^9.0.0",
+    "typescript": "^5.0.0",
+    "vite": "^5.0.0",
+    "vue-tsc": "^1.8.0",
+    "quill-next": "workspace:^2.1.0"
+  },
+  "peerDependencies": {
+    "vue": "^3.4.0",
+    "quill-next": "workspace:^2.1.0"
+  }
+}

--- a/packages/quill-next-vue/src/components/quill-editor.vue
+++ b/packages/quill-next-vue/src/components/quill-editor.vue
@@ -1,0 +1,98 @@
+<template>
+	<div ref="quill-container"></div>
+</template>
+
+<script setup lang="ts">
+import { BlotConstructor } from 'parchment'
+import { useTemplateRef, watch, watchEffect } from 'vue'
+import { Delta, EmitterSource, QuillOptions, Range } from 'quill-next'
+import Quill from 'quill-next'
+import { useQuill } from '../composables/use-quill'
+import { deltasAreEqual } from '../delta-helpers'
+
+export interface QuillEditorProps {
+	readOnly?: boolean
+	config?: QuillOptions
+	onReady?: (quill: Quill) => void
+	blots?: BlotConstructor[]
+}
+
+interface Emits {
+	(
+		event: 'text-change',
+		delta: Delta,
+		oldContent: Delta,
+		source: EmitterSource
+	): void
+	(
+		event: 'selection-change',
+		range: Range,
+		oldRange: Range,
+		source: EmitterSource
+	): void
+	(event: 'ready', quill: Quill)
+}
+
+const model = defineModel<Delta>('modelValue', {
+	default: () => new Delta(),
+	required: false,
+})
+
+const props = defineProps<QuillEditorProps>()
+const emits = defineEmits<Emits>()
+
+let initialized = false
+const containerRef = useTemplateRef<HTMLDivElement>('quill-container')
+
+const { quill } = useQuill(containerRef, props.config, props.blots)
+
+defineExpose({
+	quill,
+})
+
+watchEffect(() => {
+	if (quill.value && !initialized) {
+		initQuill()
+	}
+})
+
+watch(
+	model,
+	(newValue) => {
+		if (!deltasAreEqual(newValue, quill.value?.getContents())) {
+			quill.value?.setContents(newValue, 'user')
+		}
+	},
+	{
+		deep: true,
+		immediate: true,
+	}
+)
+
+function initQuill() {
+	initialized = true
+
+	quill.value.on('ready', () => {
+		emits('ready', quill.value)
+
+		if (model.value) {
+			quill.value.setContents(model.value)
+		}
+	})
+
+	quill.value.on(
+		'text-change',
+		(delta: Delta, oldContent: Delta, source: EmitterSource) => {
+			model.value = quill.value.getContents()
+			emits('text-change', delta, oldContent, source)
+		}
+	)
+
+	quill.value.on(
+		'selection-change',
+		(range: Range, oldRange: Range, source: EmitterSource) => {
+			emits('selection-change', range, oldRange, source)
+		}
+	)
+}
+</script>

--- a/packages/quill-next-vue/src/composables/use-quill.ts
+++ b/packages/quill-next-vue/src/composables/use-quill.ts
@@ -1,0 +1,32 @@
+import { onMounted, shallowRef, useTemplateRef, type ShallowRef } from 'vue'
+import { defaultConfig } from '../default-config'
+import { merge } from 'lodash-es'
+import Quill, { QuillOptions } from 'quill-next'
+import { makeQuillWithBlots } from '../init'
+import { type BlotConstructor } from 'parchment'
+
+type UseQuillReturn = {
+	quill: Readonly<ShallowRef<Quill | null>>
+}
+
+function useQuill(
+	templateRef: ReturnType<typeof useTemplateRef<HTMLDivElement>>,
+	config: QuillOptions = {},
+	blots?: BlotConstructor[]
+): UseQuillReturn {
+	const quill = shallowRef<Quill | null>(null)
+
+	onMounted(() => {
+		quill.value = makeQuillWithBlots(
+			templateRef.value,
+			merge({}, defaultConfig, config),
+			blots
+		)
+	})
+
+	return {
+		quill,
+	}
+}
+
+export { useQuill, type UseQuillReturn }

--- a/packages/quill-next-vue/src/default-config.ts
+++ b/packages/quill-next-vue/src/default-config.ts
@@ -1,0 +1,13 @@
+import type { QuillOptions } from 'quill-next'
+
+export const defaultConfig: QuillOptions = {
+	theme: 'snow',
+	modules: {
+		toolbar: [
+			[{ header: [1, 2, false] }],
+			['bold', 'italic', 'underline'],
+			['link', 'image'],
+			['clean'],
+		],
+	},
+}

--- a/packages/quill-next-vue/src/delta-helpers.ts
+++ b/packages/quill-next-vue/src/delta-helpers.ts
@@ -1,0 +1,8 @@
+import { Delta } from 'quill-next'
+import { isEqual } from 'lodash-es'
+
+function deltasAreEqual(delta1: Delta, delta2: Delta): boolean {
+	return isEqual(delta1, delta2)
+}
+
+export { deltasAreEqual }

--- a/packages/quill-next-vue/src/index.ts
+++ b/packages/quill-next-vue/src/index.ts
@@ -1,0 +1,6 @@
+import QuillEditor, {
+	type QuillEditorProps,
+} from './components/quill-editor.vue'
+import { useQuill } from './composables/use-quill'
+
+export { QuillEditor as default, useQuill, type QuillEditorProps }

--- a/packages/quill-next-vue/src/init.ts
+++ b/packages/quill-next-vue/src/init.ts
@@ -1,0 +1,63 @@
+import Quill, { type QuillOptions } from 'quill-next'
+import { NextTheme } from './next-theme'
+import { BlotConstructor } from 'parchment'
+
+function makeQuillWithBlots(
+	container: HTMLElement,
+	options: QuillOptions,
+	blots?: BlotConstructor[]
+): Quill {
+	const originalImports = Quill.imports
+	const newImports = {
+		...originalImports,
+	}
+
+	let quill: Quill
+	try {
+		Quill.imports = newImports
+
+		Quill.register('themes/next', NextTheme)
+
+		blots?.forEach((blot) => {
+			Quill.register(blot, true)
+		})
+		quill = new Quill(container, options)
+	} finally {
+		Quill.imports = originalImports
+	}
+
+	return quill
+}
+
+async function loadTheme(theme: string): Promise<void> {
+	const insertTheme = (theme: string, content: string): void => {
+		let styleElement: HTMLStyleElement | null = null
+		const existingStyleElement = document.head.querySelectorAll(
+			`style[data-quill-theme="${theme}"]`
+		)
+		if (existingStyleElement.length > 0) {
+			// remove all existing style elements
+			existingStyleElement.forEach((styleElement) => {
+				document.head.removeChild(styleElement)
+			})
+		}
+
+		styleElement = document.createElement('style')
+		styleElement.setAttribute('data-quill-theme', theme)
+		styleElement.setAttribute('type', 'text/css')
+		styleElement.innerHTML = content
+		document.head.appendChild(styleElement)
+	}
+
+	if (theme === 'next' || theme === 'snow') {
+		const { default: css } = await import(`quill-next/dist/quill.snow.css?raw`)
+		insertTheme(theme, css)
+	} else if (theme === 'bubble') {
+		const { default: css } = await import(
+			`quill-next/dist/quill.bubble.css?raw`
+		)
+		insertTheme(theme, css)
+	}
+}
+
+export { makeQuillWithBlots, loadTheme }

--- a/packages/quill-next-vue/src/next-theme.ts
+++ b/packages/quill-next-vue/src/next-theme.ts
@@ -1,0 +1,9 @@
+import Quill, { Theme } from "quill-next";
+
+export class NextTheme extends Theme {
+  constructor(quill: Quill, options: unknown) {
+    super(quill, options as any);
+    this.quill.container.classList.add('ql-snow');
+    this.quill.container.classList.add('ql-next');
+  }
+}

--- a/packages/quill-next-vue/tsconfig.json
+++ b/packages/quill-next-vue/tsconfig.json
@@ -1,0 +1,14 @@
+{
+	"compilerOptions": {
+		"target": "ESNext",
+		"esModuleInterop": false,
+		"allowSyntheticDefaultImports": true,
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"declaration": true,
+		"declarationDir": "./dist",
+		"rootDir": "src",
+		"emitDeclarationOnly": true
+	},
+	"include": ["src"]
+}

--- a/packages/quill-next-vue/vite.config.js
+++ b/packages/quill-next-vue/vite.config.js
@@ -1,0 +1,25 @@
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+import path from 'path'
+
+export default defineConfig({
+	root: path.resolve(__dirname, 'dev'),
+	plugins: [vue()],
+	resolve: {
+		alias: {
+			'@': path.resolve(__dirname, 'src'),
+		},
+	},
+	build: {
+		lib: {
+			entry: {
+				index: path.resolve(__dirname, 'src/index.ts'),
+			},
+			formats: ['es'],
+			fileName: (format, entryName) => `${entryName}.js`,
+		},
+	},
+	test: {
+		environment: 'jsdom',
+	},
+})


### PR DESCRIPTION
I've been using quill in a couple of my projects and very upset that quill's team forgot about it. I had hope that it will change after 2.0 release, but it seems to be only for a short period of time. 
I use quill in vue projects so a vue package is something I very much need.
This pr has only a basic implementation: just a wrapper component that works. Specific vue optimizations and some advanced functionality will be made later if this pr is accepted.
Tests are also not there:) Beacuse there is nothing to test yet, its only a wrapper 