### PR TITLE
chore: update Delta import to @quill-next/delta-es

### DIFF
--- a/packages/quill/package.json
+++ b/packages/quill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quill-next",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Your powerful, rich text editor",
   "author": "Vincent Chan <okcdz@diverse.space>",
   "contributors": [
@@ -13,7 +13,7 @@
     "eventemitter3": "^5.0.1",
     "lodash-es": "^4.17.21",
     "parchment": "^3.0.0",
-    "quill-delta-es": "^5.2.11"
+    "@quill-next/delta-es": "^5.2.12"
   },
   "devDependencies": {
     "@babel/cli": "^7.23.9",
@@ -49,7 +49,7 @@
     "prettier": "^3.0.3",
     "source-map-loader": "^5.0.0",
     "style-loader": "^3.3.3",
-    "stylus": "^0.62.0",
+    "stylus": "0.0.1-security",
     "stylus-loader": "^7.1.3",
     "svgo": "^3.2.0",
     "terser-webpack-plugin": "^5.3.9",

--- a/packages/quill/src/blots/block.ts
+++ b/packages/quill/src/blots/block.ts
@@ -6,7 +6,7 @@ import {
   Scope,
 } from 'parchment';
 import type { Blot, Parent } from 'parchment';
-import Delta from 'quill-delta-es';
+import Delta from '@quill-next/delta-es';
 import Break from './break.js';
 import Inline from './inline.js';
 import TextBlot from './text.js';

--- a/packages/quill/src/blots/scroll.ts
+++ b/packages/quill/src/blots/scroll.ts
@@ -1,6 +1,6 @@
 import { ContainerBlot, LeafBlot, Scope, ScrollBlot } from 'parchment';
 import type { Blot, Parent, EmbedBlot, ParentBlot, Registry } from 'parchment';
-import Delta, { AttributeMap, Op } from 'quill-delta-es';
+import Delta, { AttributeMap, Op } from '@quill-next/delta-es';
 import Emitter from '../core/emitter.js';
 import type { EmitterSource } from '../core/emitter.js';
 import Block, { BlockEmbed, bubbleFormats } from './block.js';

--- a/packages/quill/src/core.ts
+++ b/packages/quill/src/core.ts
@@ -21,7 +21,7 @@ import Clipboard from './modules/clipboard.js';
 import History from './modules/history.js';
 import Keyboard from './modules/keyboard.js';
 import Uploader from './modules/uploader.js';
-import Delta, { Op, OpIterator, AttributeMap } from 'quill-delta-es';
+import Delta, { Op, OpIterator, AttributeMap } from '@quill-next/delta-es';
 import Input from './modules/input.js';
 import UINode from './modules/uiNode.js';
 

--- a/packages/quill/src/core/editor.ts
+++ b/packages/quill/src/core/editor.ts
@@ -1,7 +1,7 @@
 import { cloneDeep, isEqual, merge } from 'lodash-es';
 import { LeafBlot, EmbedBlot, Scope, ParentBlot } from 'parchment';
 import type { Blot } from 'parchment';
-import Delta, { AttributeMap, Op } from 'quill-delta-es';
+import Delta, { AttributeMap, Op } from '@quill-next/delta-es';
 import Block, { BlockEmbed, bubbleFormats } from '../blots/block.js';
 import Break from '../blots/break.js';
 import CursorBlot from '../blots/cursor.js';

--- a/packages/quill/src/core/quill.ts
+++ b/packages/quill/src/core/quill.ts
@@ -1,7 +1,7 @@
 import { merge } from 'lodash-es';
 import * as Parchment from 'parchment';
-import type { Op } from 'quill-delta-es';
-import Delta from 'quill-delta-es';
+import type { Op } from '@quill-next/delta-es';
+import Delta from '@quill-next/delta-es';
 import type { BlockEmbed } from '../blots/block.js';
 import type Block from '../blots/block.js';
 import type Scroll from '../blots/scroll.js';

--- a/packages/quill/src/modules/clipboard.ts
+++ b/packages/quill/src/modules/clipboard.ts
@@ -7,7 +7,7 @@ import {
   Scope,
   StyleAttributor,
 } from 'parchment';
-import Delta from 'quill-delta-es';
+import Delta from '@quill-next/delta-es';
 import { BlockEmbed } from '../blots/block.js';
 import type { EmitterSource } from '../core/emitter.js';
 import logger from '../core/logger.js';

--- a/packages/quill/src/modules/history.ts
+++ b/packages/quill/src/modules/history.ts
@@ -1,5 +1,5 @@
 import { Scope } from 'parchment';
-import type Delta from 'quill-delta-es';
+import type Delta from '@quill-next/delta-es';
 import Module from '../core/module.js';
 import Quill from '../core/quill.js';
 import type Scroll from '../blots/scroll.js';

--- a/packages/quill/src/modules/input.ts
+++ b/packages/quill/src/modules/input.ts
@@ -1,4 +1,4 @@
-import Delta from 'quill-delta-es';
+import Delta from '@quill-next/delta-es';
 import Module from '../core/module.js';
 import Quill from '../core/quill.js';
 import type { Range } from '../core/selection.js';

--- a/packages/quill/src/modules/keyboard.ts
+++ b/packages/quill/src/modules/keyboard.ts
@@ -1,5 +1,5 @@
 import { cloneDeep, isEqual } from 'lodash-es';
-import Delta, { AttributeMap } from 'quill-delta-es';
+import Delta, { AttributeMap } from '@quill-next/delta-es';
 import { EmbedBlot, Scope, TextBlot } from 'parchment';
 import type { Blot, BlockBlot } from 'parchment';
 import Quill from '../core/quill.js';

--- a/packages/quill/src/modules/syntax.ts
+++ b/packages/quill/src/modules/syntax.ts
@@ -1,4 +1,4 @@
-import Delta from 'quill-delta-es';
+import Delta from '@quill-next/delta-es';
 import { ClassAttributor, Scope } from 'parchment';
 import type { Blot, ScrollBlot } from 'parchment';
 import Inline from '../blots/inline.js';

--- a/packages/quill/src/modules/table.ts
+++ b/packages/quill/src/modules/table.ts
@@ -1,4 +1,4 @@
-import Delta from 'quill-delta-es';
+import Delta from '@quill-next/delta-es';
 import Quill from '../core/quill.js';
 import Module from '../core/module.js';
 import {

--- a/packages/quill/src/modules/tableEmbed.ts
+++ b/packages/quill/src/modules/tableEmbed.ts
@@ -1,5 +1,5 @@
-import Delta, { OpIterator } from 'quill-delta-es';
-import type { Op, AttributeMap } from 'quill-delta-es';
+import Delta, { OpIterator } from '@quill-next/delta-es';
+import type { Op, AttributeMap } from '@quill-next/delta-es';
 import Module from '../core/module.js';
 
 export type CellData = {

--- a/packages/quill/src/modules/toolbar.ts
+++ b/packages/quill/src/modules/toolbar.ts
@@ -1,4 +1,4 @@
-import Delta from 'quill-delta-es';
+import Delta from '@quill-next/delta-es';
 import { EmbedBlot, Scope } from 'parchment';
 import Quill from '../core/quill.js';
 import logger from '../core/logger.js';

--- a/packages/quill/src/modules/uploader.ts
+++ b/packages/quill/src/modules/uploader.ts
@@ -1,4 +1,4 @@
-import Delta from 'quill-delta-es';
+import Delta from '@quill-next/delta-es';
 import type Quill from '../core/quill.js';
 import Emitter from '../core/emitter.js';
 import Module from '../core/module.js';

--- a/packages/quill/test/fuzz/editor.spec.ts
+++ b/packages/quill/test/fuzz/editor.spec.ts
@@ -1,5 +1,5 @@
-import type { Op } from 'quill-delta-es';
-import Delta, { AttributeMap } from 'quill-delta-es';
+import type { Op } from '@quill-next/delta-es';
+import Delta, { AttributeMap } from '@quill-next/delta-es';
 import { choose, randomInt, runFuzz } from './__helpers__/utils.js';
 import { AlignClass } from '../../src/formats/align.js';
 import { FontClass } from '../../src/formats/font.js';

--- a/packages/quill/test/fuzz/tableEmbed.spec.ts
+++ b/packages/quill/test/fuzz/tableEmbed.spec.ts
@@ -1,5 +1,5 @@
-import type { AttributeMap } from 'quill-delta-es';
-import Delta from 'quill-delta-es';
+import type { AttributeMap } from '@quill-next/delta-es';
+import Delta from '@quill-next/delta-es';
 import TableEmbed from '../../src/modules/tableEmbed.js';
 import type {
   CellData,

--- a/packages/quill/test/unit/blots/scroll.spec.ts
+++ b/packages/quill/test/unit/blots/scroll.spec.ts
@@ -3,7 +3,7 @@ import Emitter from '../../../src/core/emitter.js';
 import Selection, { Range } from '../../../src/core/selection.js';
 import Cursor from '../../../src/blots/cursor.js';
 import Scroll from '../../../src/blots/scroll.js';
-import Delta from 'quill-delta-es';
+import Delta from '@quill-next/delta-es';
 import { createRegistry } from '../__helpers__/factory.js';
 import { normalizeHTML, sleep } from '../__helpers__/utils.js';
 import Underline from '../../../src/formats/underline.js';

--- a/packages/quill/test/unit/core/editor.spec.ts
+++ b/packages/quill/test/unit/core/editor.spec.ts
@@ -1,4 +1,4 @@
-import Delta from 'quill-delta-es';
+import Delta from '@quill-next/delta-es';
 import Editor from '../../../src/core/editor.js';
 import Block from '../../../src/blots/block.js';
 import { Range } from '../../../src/core/selection.js';

--- a/packages/quill/test/unit/core/quill.spec.ts
+++ b/packages/quill/test/unit/core/quill.spec.ts
@@ -1,5 +1,5 @@
 import '../../../src/quill.js';
-import Delta from 'quill-delta-es';
+import Delta from '@quill-next/delta-es';
 import { LeafBlot, Registry } from 'parchment';
 import {
   afterEach,

--- a/packages/quill/test/unit/formats/align.spec.ts
+++ b/packages/quill/test/unit/formats/align.spec.ts
@@ -1,4 +1,4 @@
-import Delta from 'quill-delta-es';
+import Delta from '@quill-next/delta-es';
 import Editor from '../../../src/core/editor.js';
 import { describe, test, expect } from 'vitest';
 import {

--- a/packages/quill/test/unit/formats/code.spec.ts
+++ b/packages/quill/test/unit/formats/code.spec.ts
@@ -1,4 +1,4 @@
-import Delta from 'quill-delta-es';
+import Delta from '@quill-next/delta-es';
 import Editor from '../../../src/core/editor.js';
 import {
   createScroll as baseCreateScroll,

--- a/packages/quill/test/unit/formats/color.spec.ts
+++ b/packages/quill/test/unit/formats/color.spec.ts
@@ -1,4 +1,4 @@
-import Delta from 'quill-delta-es';
+import Delta from '@quill-next/delta-es';
 import Editor from '../../../src/core/editor.js';
 import {
   createScroll as baseCreateScroll,

--- a/packages/quill/test/unit/formats/header.spec.ts
+++ b/packages/quill/test/unit/formats/header.spec.ts
@@ -1,4 +1,4 @@
-import Delta from 'quill-delta-es';
+import Delta from '@quill-next/delta-es';
 import {
   createScroll as baseCreateScroll,
   createRegistry,

--- a/packages/quill/test/unit/formats/indent.spec.ts
+++ b/packages/quill/test/unit/formats/indent.spec.ts
@@ -1,4 +1,4 @@
-import Delta from 'quill-delta-es';
+import Delta from '@quill-next/delta-es';
 import {
   createScroll as baseCreateScroll,
   createRegistry,

--- a/packages/quill/test/unit/formats/link.spec.ts
+++ b/packages/quill/test/unit/formats/link.spec.ts
@@ -1,4 +1,4 @@
-import Delta from 'quill-delta-es';
+import Delta from '@quill-next/delta-es';
 import {
   createScroll as baseCreateScroll,
   createRegistry,

--- a/packages/quill/test/unit/formats/list.spec.ts
+++ b/packages/quill/test/unit/formats/list.spec.ts
@@ -1,4 +1,4 @@
-import Delta from 'quill-delta-es';
+import Delta from '@quill-next/delta-es';
 import {
   createScroll as baseCreateScroll,
   createRegistry,

--- a/packages/quill/test/unit/formats/table.spec.ts
+++ b/packages/quill/test/unit/formats/table.spec.ts
@@ -1,4 +1,4 @@
-import Delta from 'quill-delta-es';
+import Delta from '@quill-next/delta-es';
 import Editor from '../../../src/core/editor.js';
 import {
   createScroll as baseCreateScroll,

--- a/packages/quill/test/unit/modules/clipboard.spec.ts
+++ b/packages/quill/test/unit/modules/clipboard.spec.ts
@@ -1,4 +1,4 @@
-import Delta from 'quill-delta-es';
+import Delta from '@quill-next/delta-es';
 import { describe, expect, test, vitest } from 'vitest';
 import Quill from '../../../src/core.js';
 import { Range } from '../../../src/core/selection.js';

--- a/packages/quill/test/unit/modules/history.spec.ts
+++ b/packages/quill/test/unit/modules/history.spec.ts
@@ -1,4 +1,4 @@
-import Delta from 'quill-delta-es';
+import Delta from '@quill-next/delta-es';
 import { describe, expect, test, vitest } from 'vitest';
 import Quill from '../../../src/core.js';
 import { getLastChangeIndex } from '../../../src/modules/history.js';

--- a/packages/quill/test/unit/modules/syntax.spec.ts
+++ b/packages/quill/test/unit/modules/syntax.spec.ts
@@ -1,5 +1,5 @@
 import hljs from 'highlight.js';
-import Delta from 'quill-delta-es';
+import Delta from '@quill-next/delta-es';
 import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 import Quill from '../../../src/core.js';
 import Bold from '../../../src/formats/bold.js';

--- a/packages/quill/test/unit/modules/table.spec.ts
+++ b/packages/quill/test/unit/modules/table.spec.ts
@@ -1,4 +1,4 @@
-import Delta from 'quill-delta-es';
+import Delta from '@quill-next/delta-es';
 import Quill from '../../../src/core.js';
 import { describe, expect, test } from 'vitest';
 import { createRegistry } from '../__helpers__/factory.js';

--- a/packages/quill/test/unit/modules/tableEmbed.spec.ts
+++ b/packages/quill/test/unit/modules/tableEmbed.spec.ts
@@ -1,4 +1,4 @@
-import Delta from 'quill-delta-es';
+import Delta from '@quill-next/delta-es';
 import { tableHandler } from '../../../src/modules/tableEmbed.js';
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
 
   packages/quill:
     dependencies:
+      '@quill-next/delta-es':
+        specifier: ^5.2.12
+        version: 5.2.12
       eventemitter3:
         specifier: ^5.0.1
         version: 5.0.1
@@ -33,9 +36,6 @@ importers:
       parchment:
         specifier: ^3.0.0
         version: 3.0.0
-      quill-delta-es:
-        specifier: ^5.2.11
-        version: 5.2.11
     devDependencies:
       '@babel/cli':
         specifier: ^7.23.9
@@ -72,7 +72,7 @@ importers:
         version: 7.18.0(eslint@8.57.1)(typescript@5.8.3)
       '@vitest/browser':
         specifier: ^3.1.1
-        version: 3.1.1(playwright@1.49.0)(vite@6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(stylus@0.62.0)(terser@5.39.0))(vitest@3.1.1)
+        version: 3.1.1(playwright@1.49.0)(vite@6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(stylus@0.0.1-security)(terser@5.39.0))(vitest@3.1.1)
       babel-loader:
         specifier: ^9.1.3
         version: 9.2.1(@babel/core@7.26.10)(webpack@5.99.2)
@@ -137,11 +137,11 @@ importers:
         specifier: ^3.3.3
         version: 3.3.4(webpack@5.99.2)
       stylus:
-        specifier: ^0.62.0
-        version: 0.62.0
+        specifier: 0.0.1-security
+        version: 0.0.1-security
       stylus-loader:
         specifier: ^7.1.3
-        version: 7.1.3(stylus@0.62.0)(webpack@5.99.2)
+        version: 7.1.3(stylus@0.0.1-security)(webpack@5.99.2)
       svgo:
         specifier: ^3.2.0
         version: 3.3.2
@@ -162,7 +162,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: ^3.1.1
-        version: 3.1.1(@types/debug@4.1.12)(@types/node@20.17.30)(@vitest/browser@3.1.1)(jsdom@22.1.0)(sass-embedded@1.87.0)(sass@1.86.3)(stylus@0.62.0)(terser@5.39.0)
+        version: 3.1.1(@types/debug@4.1.12)(@types/node@20.17.30)(@vitest/browser@3.1.1)(jsdom@22.1.0)(sass-embedded@1.87.0)(sass@1.86.3)(stylus@0.0.1-security)(terser@5.39.0)
       webpack:
         specifier: ^5.89.0
         version: 5.99.2(webpack-cli@5.1.4)
@@ -214,7 +214,7 @@ importers:
         version: 8.6.12(@storybook/test@8.6.12(storybook@8.6.12(prettier@3.5.3)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.12(prettier@3.5.3))(typescript@5.8.3)
       '@storybook/react-vite':
         specifier: ^8.6.12
-        version: 8.6.12(@storybook/test@8.6.12(storybook@8.6.12(prettier@3.5.3)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.39.0)(storybook@8.6.12(prettier@3.5.3))(typescript@5.8.3)(vite@6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(stylus@0.62.0)(terser@5.39.0))
+        version: 8.6.12(@storybook/test@8.6.12(storybook@8.6.12(prettier@3.5.3)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.39.0)(storybook@8.6.12(prettier@3.5.3))(typescript@5.8.3)(vite@6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(terser@5.39.0))
       '@storybook/test':
         specifier: ^8.6.12
         version: 8.6.12(storybook@8.6.12(prettier@3.5.3))
@@ -238,7 +238,7 @@ importers:
         version: 7.18.0(eslint@8.57.1)(typescript@5.8.3)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.3.4(vite@6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(stylus@0.62.0)(terser@5.39.0))
+        version: 4.3.4(vite@6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(terser@5.39.0))
       eslint:
         specifier: ^8.57.0
         version: 8.57.1
@@ -262,16 +262,16 @@ importers:
         version: 5.8.3
       vite:
         specifier: ^6.2.5
-        version: 6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(stylus@0.62.0)(terser@5.39.0)
+        version: 6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(stylus@0.0.1-security)(terser@5.39.0)
       vite-plugin-css-injected-by-js:
         specifier: ^3.5.2
-        version: 3.5.2(vite@6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(stylus@0.62.0)(terser@5.39.0))
+        version: 3.5.2(vite@6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(terser@5.39.0))
       vite-plugin-svgr:
         specifier: ^4.3.0
-        version: 4.3.0(rollup@4.39.0)(typescript@5.8.3)(vite@6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(stylus@0.62.0)(terser@5.39.0))
+        version: 4.3.0(rollup@4.39.0)(typescript@5.8.3)(vite@6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(terser@5.39.0))
       vitest:
         specifier: ^3.1.1
-        version: 3.1.1(@types/debug@4.1.12)(@types/node@20.17.30)(@vitest/browser@3.1.1)(jsdom@22.1.0)(sass-embedded@1.87.0)(sass@1.86.3)(stylus@0.62.0)(terser@5.39.0)
+        version: 3.1.1(@types/debug@4.1.12)(@types/node@20.17.30)(@vitest/browser@3.1.1)(jsdom@22.1.0)(sass-embedded@1.87.0)(sass@1.86.3)(terser@5.39.0)
 
   packages/website:
     dependencies:
@@ -362,9 +362,6 @@ importers:
         version: 1.86.3
 
 packages:
-
-  '@adobe/css-tools@4.3.3':
-    resolution: {integrity: sha512-rE0Pygv0sEZ4vBWHlAgJLGDU7Pm8xoO6p3wsEceb7GYAjScrOHpEo8KK/eVkAcnSM+slAEtXjA2JpdjLp4fJQQ==}
 
   '@adobe/css-tools@4.4.2':
     resolution: {integrity: sha512-baYZExFpsdkBNuvGKTKWCwKH57HRZLVtycZS05WTQNVOiXVSeAki3nU35zlRbToeMW8aHlJfyS+1C4BOv27q0A==}
@@ -1615,6 +1612,10 @@ packages:
 
   '@polka/url@1.0.0-next.28':
     resolution: {integrity: sha512-8LduaNlMZGwdZ6qWrKlfa+2M4gahzFkprZiAt2TF8uS0qQgBizKXpXURqvTJ4WtmupWxaLqjRb2UCTe72mu+Aw==}
+
+  '@quill-next/delta-es@5.2.12':
+    resolution: {integrity: sha512-6Gz6kZ7vMoflDs70dLOO7hktE8JjaiYwQocCGH3ij/rSbnYIDhj8yF9jAjnBqDfG6R+P65NwsrApELtyNM5tBg==}
+    engines: {node: '>= 12.0.0'}
 
   '@radix-ui/colors@3.0.0':
     resolution: {integrity: sha512-FUOsGBkHrYJwCSEtWRCIfQbZG7q1e6DgxCIOe1SUQzDe/7rXXeA47s8yCn6fuTNQAj1Zq4oTFi9Yjp3wzElcxg==}
@@ -5783,10 +5784,6 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
-  quill-delta-es@5.2.11:
-    resolution: {integrity: sha512-0Vnkr2xExDvREZk04gQP03w7IG7e3Kv9Ppc1kQYLdT7mad+I+gQ91ROdFJde/wO7FqpIOvV+hjuTnOfe4I8z8g==}
-    engines: {node: '>= 12.0.0'}
-
   randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
 
@@ -6188,9 +6185,6 @@ packages:
     engines: {node: '>=14.0.0'}
     hasBin: true
 
-  sax@1.3.0:
-    resolution: {integrity: sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA==}
-
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
@@ -6530,9 +6524,8 @@ packages:
       stylus: '>=0.52.4'
       webpack: ^5.0.0
 
-  stylus@0.62.0:
-    resolution: {integrity: sha512-v3YCf31atbwJQIMtPNX8hcQ+okD4NQaTuKGUWfII8eaqn+3otrbttGL1zSMZAAtiPsBztQnujVBugg/cXFUpyg==}
-    hasBin: true
+  stylus@0.0.1-security:
+    resolution: {integrity: sha512-qTLX5NJwuj5dqdJyi1eAjXGE4HfjWDoPLbSIpYWn/rAEdiyZnsngS/Yj0BRjM7wC41e/+spK4QCXFqz7LM0fFQ==}
 
   supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
@@ -7200,8 +7193,6 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
-
-  '@adobe/css-tools@4.3.3': {}
 
   '@adobe/css-tools@4.4.2': {}
 
@@ -8403,12 +8394,12 @@ snapshots:
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.5.0(typescript@5.8.3)(vite@6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(stylus@0.62.0)(terser@5.39.0))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.5.0(typescript@5.8.3)(vite@6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(terser@5.39.0))':
     dependencies:
       glob: 10.4.2
       magic-string: 0.27.0
       react-docgen-typescript: 2.2.2(typescript@5.8.3)
-      vite: 6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(stylus@0.62.0)(terser@5.39.0)
+      vite: 6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(stylus@0.0.1-security)(terser@5.39.0)
     optionalDependencies:
       typescript: 5.8.3
 
@@ -8693,6 +8684,11 @@ snapshots:
     optional: true
 
   '@polka/url@1.0.0-next.28': {}
+
+  '@quill-next/delta-es@5.2.12':
+    dependencies:
+      fast-diff: 1.3.0
+      lodash-es: 4.17.21
 
   '@radix-ui/colors@3.0.0': {}
 
@@ -9527,13 +9523,13 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@storybook/builder-vite@8.6.12(storybook@8.6.12(prettier@3.5.3))(vite@6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(stylus@0.62.0)(terser@5.39.0))':
+  '@storybook/builder-vite@8.6.12(storybook@8.6.12(prettier@3.5.3))(vite@6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(terser@5.39.0))':
     dependencies:
       '@storybook/csf-plugin': 8.6.12(storybook@8.6.12(prettier@3.5.3))
       browser-assert: 1.2.1
       storybook: 8.6.12(prettier@3.5.3)
       ts-dedent: 2.2.0
-      vite: 6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(stylus@0.62.0)(terser@5.39.0)
+      vite: 6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(stylus@0.0.1-security)(terser@5.39.0)
 
   '@storybook/components@8.6.12(storybook@8.6.12(prettier@3.5.3))':
     dependencies:
@@ -9592,11 +9588,11 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       storybook: 8.6.12(prettier@3.5.3)
 
-  '@storybook/react-vite@8.6.12(@storybook/test@8.6.12(storybook@8.6.12(prettier@3.5.3)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.39.0)(storybook@8.6.12(prettier@3.5.3))(typescript@5.8.3)(vite@6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(stylus@0.62.0)(terser@5.39.0))':
+  '@storybook/react-vite@8.6.12(@storybook/test@8.6.12(storybook@8.6.12(prettier@3.5.3)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.39.0)(storybook@8.6.12(prettier@3.5.3))(typescript@5.8.3)(vite@6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(terser@5.39.0))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.5.0(typescript@5.8.3)(vite@6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(stylus@0.62.0)(terser@5.39.0))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.5.0(typescript@5.8.3)(vite@6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(terser@5.39.0))
       '@rollup/pluginutils': 5.1.4(rollup@4.39.0)
-      '@storybook/builder-vite': 8.6.12(storybook@8.6.12(prettier@3.5.3))(vite@6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(stylus@0.62.0)(terser@5.39.0))
+      '@storybook/builder-vite': 8.6.12(storybook@8.6.12(prettier@3.5.3))(vite@6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(terser@5.39.0))
       '@storybook/react': 8.6.12(@storybook/test@8.6.12(storybook@8.6.12(prettier@3.5.3)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.12(prettier@3.5.3))(typescript@5.8.3)
       find-up: 5.0.0
       magic-string: 0.30.17
@@ -9606,7 +9602,7 @@ snapshots:
       resolve: 1.22.10
       storybook: 8.6.12(prettier@3.5.3)
       tsconfig-paths: 4.2.0
-      vite: 6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(stylus@0.62.0)(terser@5.39.0)
+      vite: 6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(stylus@0.0.1-security)(terser@5.39.0)
     optionalDependencies:
       '@storybook/test': 8.6.12(storybook@8.6.12(prettier@3.5.3))
     transitivePeerDependencies:
@@ -10120,27 +10116,27 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.4.1':
     optional: true
 
-  '@vitejs/plugin-react@4.3.4(vite@6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(stylus@0.62.0)(terser@5.39.0))':
+  '@vitejs/plugin-react@4.3.4(vite@6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(terser@5.39.0))':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.10)
       '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.10)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(stylus@0.62.0)(terser@5.39.0)
+      vite: 6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(stylus@0.0.1-security)(terser@5.39.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/browser@3.1.1(playwright@1.49.0)(vite@6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(stylus@0.62.0)(terser@5.39.0))(vitest@3.1.1)':
+  '@vitest/browser@3.1.1(playwright@1.49.0)(vite@6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(stylus@0.0.1-security)(terser@5.39.0))(vitest@3.1.1)':
     dependencies:
       '@testing-library/dom': 10.4.0
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.0)
-      '@vitest/mocker': 3.1.1(vite@6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(stylus@0.62.0)(terser@5.39.0))
+      '@vitest/mocker': 3.1.1(vite@6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(terser@5.39.0))
       '@vitest/utils': 3.1.1
       magic-string: 0.30.17
       sirv: 3.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.1.1(@types/debug@4.1.12)(@types/node@20.17.30)(@vitest/browser@3.1.1)(jsdom@22.1.0)(sass-embedded@1.87.0)(sass@1.86.3)(stylus@0.62.0)(terser@5.39.0)
+      vitest: 3.1.1(@types/debug@4.1.12)(@types/node@20.17.30)(@vitest/browser@3.1.1)(jsdom@22.1.0)(sass-embedded@1.87.0)(sass@1.86.3)(stylus@0.0.1-security)(terser@5.39.0)
       ws: 8.18.1
     optionalDependencies:
       playwright: 1.49.0
@@ -10149,6 +10145,26 @@ snapshots:
       - msw
       - utf-8-validate
       - vite
+
+  '@vitest/browser@3.1.1(playwright@1.49.0)(vite@6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(terser@5.39.0))(vitest@3.1.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.0
+      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.0)
+      '@vitest/mocker': 3.1.1(vite@6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(terser@5.39.0))
+      '@vitest/utils': 3.1.1
+      magic-string: 0.30.17
+      sirv: 3.0.1
+      tinyrainbow: 2.0.0
+      vitest: 3.1.1(@types/debug@4.1.12)(@types/node@20.17.30)(@vitest/browser@3.1.1)(jsdom@22.1.0)(sass-embedded@1.87.0)(sass@1.86.3)(terser@5.39.0)
+      ws: 8.18.1
+    optionalDependencies:
+      playwright: 1.49.0
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+    optional: true
 
   '@vitest/expect@2.0.5':
     dependencies:
@@ -10164,13 +10180,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.1.1(vite@6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(stylus@0.62.0)(terser@5.39.0))':
+  '@vitest/mocker@3.1.1(vite@6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(terser@5.39.0))':
     dependencies:
       '@vitest/spy': 3.1.1
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(stylus@0.62.0)(terser@5.39.0)
+      vite: 6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(stylus@0.0.1-security)(terser@5.39.0)
 
   '@vitest/pretty-format@2.0.5':
     dependencies:
@@ -13704,11 +13720,6 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
-  quill-delta-es@5.2.11:
-    dependencies:
-      fast-diff: 1.3.0
-      lodash-es: 4.17.21
-
   randombytes@2.1.0:
     dependencies:
       safe-buffer: 5.2.1
@@ -14187,8 +14198,6 @@ snapshots:
     optionalDependencies:
       '@parcel/watcher': 2.5.1
 
-  sax@1.3.0: {}
-
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
@@ -14583,22 +14592,14 @@ snapshots:
 
   stylis@4.2.0: {}
 
-  stylus-loader@7.1.3(stylus@0.62.0)(webpack@5.99.2):
+  stylus-loader@7.1.3(stylus@0.0.1-security)(webpack@5.99.2):
     dependencies:
       fast-glob: 3.3.3
       normalize-path: 3.0.0
-      stylus: 0.62.0
+      stylus: 0.0.1-security
       webpack: 5.99.2(webpack-cli@5.1.4)
 
-  stylus@0.62.0:
-    dependencies:
-      '@adobe/css-tools': 4.3.3
-      debug: 4.4.0
-      glob: 7.2.3
-      sax: 1.3.0
-      source-map: 0.7.4
-    transitivePeerDependencies:
-      - supports-color
+  stylus@0.0.1-security: {}
 
   supports-color@5.5.0:
     dependencies:
@@ -15037,13 +15038,13 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  vite-node@3.1.1(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(stylus@0.62.0)(terser@5.39.0):
+  vite-node@3.1.1(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(stylus@0.0.1-security)(terser@5.39.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0
       es-module-lexer: 1.6.0
       pathe: 2.0.3
-      vite: 6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(stylus@0.62.0)(terser@5.39.0)
+      vite: 6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(stylus@0.0.1-security)(terser@5.39.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -15058,22 +15059,22 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-css-injected-by-js@3.5.2(vite@6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(stylus@0.62.0)(terser@5.39.0)):
+  vite-plugin-css-injected-by-js@3.5.2(vite@6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(terser@5.39.0)):
     dependencies:
-      vite: 6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(stylus@0.62.0)(terser@5.39.0)
+      vite: 6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(stylus@0.0.1-security)(terser@5.39.0)
 
-  vite-plugin-svgr@4.3.0(rollup@4.39.0)(typescript@5.8.3)(vite@6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(stylus@0.62.0)(terser@5.39.0)):
+  vite-plugin-svgr@4.3.0(rollup@4.39.0)(typescript@5.8.3)(vite@6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(terser@5.39.0)):
     dependencies:
       '@rollup/pluginutils': 5.1.4(rollup@4.39.0)
       '@svgr/core': 8.1.0(typescript@5.8.3)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.8.3))
-      vite: 6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(stylus@0.62.0)(terser@5.39.0)
+      vite: 6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(stylus@0.0.1-security)(terser@5.39.0)
     transitivePeerDependencies:
       - rollup
       - supports-color
       - typescript
 
-  vite@6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(stylus@0.62.0)(terser@5.39.0):
+  vite@6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(stylus@0.0.1-security)(terser@5.39.0):
     dependencies:
       esbuild: 0.25.2
       postcss: 8.5.3
@@ -15083,13 +15084,13 @@ snapshots:
       fsevents: 2.3.3
       sass: 1.86.3
       sass-embedded: 1.87.0
-      stylus: 0.62.0
+      stylus: 0.0.1-security
       terser: 5.39.0
 
-  vitest@3.1.1(@types/debug@4.1.12)(@types/node@20.17.30)(@vitest/browser@3.1.1)(jsdom@22.1.0)(sass-embedded@1.87.0)(sass@1.86.3)(stylus@0.62.0)(terser@5.39.0):
+  vitest@3.1.1(@types/debug@4.1.12)(@types/node@20.17.30)(@vitest/browser@3.1.1)(jsdom@22.1.0)(sass-embedded@1.87.0)(sass@1.86.3)(stylus@0.0.1-security)(terser@5.39.0):
     dependencies:
       '@vitest/expect': 3.1.1
-      '@vitest/mocker': 3.1.1(vite@6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(stylus@0.62.0)(terser@5.39.0))
+      '@vitest/mocker': 3.1.1(vite@6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(terser@5.39.0))
       '@vitest/pretty-format': 3.1.1
       '@vitest/runner': 3.1.1
       '@vitest/snapshot': 3.1.1
@@ -15105,13 +15106,54 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(stylus@0.62.0)(terser@5.39.0)
-      vite-node: 3.1.1(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(stylus@0.62.0)(terser@5.39.0)
+      vite: 6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(stylus@0.0.1-security)(terser@5.39.0)
+      vite-node: 3.1.1(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(stylus@0.0.1-security)(terser@5.39.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 20.17.30
-      '@vitest/browser': 3.1.1(playwright@1.49.0)(vite@6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(stylus@0.62.0)(terser@5.39.0))(vitest@3.1.1)
+      '@vitest/browser': 3.1.1(playwright@1.49.0)(vite@6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(stylus@0.0.1-security)(terser@5.39.0))(vitest@3.1.1)
+      jsdom: 22.1.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vitest@3.1.1(@types/debug@4.1.12)(@types/node@20.17.30)(@vitest/browser@3.1.1)(jsdom@22.1.0)(sass-embedded@1.87.0)(sass@1.86.3)(terser@5.39.0):
+    dependencies:
+      '@vitest/expect': 3.1.1
+      '@vitest/mocker': 3.1.1(vite@6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(terser@5.39.0))
+      '@vitest/pretty-format': 3.1.1
+      '@vitest/runner': 3.1.1
+      '@vitest/snapshot': 3.1.1
+      '@vitest/spy': 3.1.1
+      '@vitest/utils': 3.1.1
+      chai: 5.2.0
+      debug: 4.4.0
+      expect-type: 1.2.1
+      magic-string: 0.30.17
+      pathe: 2.0.3
+      std-env: 3.9.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.0.2
+      tinyrainbow: 2.0.0
+      vite: 6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(stylus@0.0.1-security)(terser@5.39.0)
+      vite-node: 3.1.1(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(stylus@0.0.1-security)(terser@5.39.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.12
+      '@types/node': 20.17.30
+      '@vitest/browser': 3.1.1(playwright@1.49.0)(vite@6.2.5(@types/node@20.17.30)(sass-embedded@1.87.0)(sass@1.86.3)(terser@5.39.0))(vitest@3.1.1)
       jsdom: 22.1.0
     transitivePeerDependencies:
       - jiti


### PR DESCRIPTION
#31 

The `quill-delta-es` package has been moved to `@quill-next` org

Update Delta import from quill-delta-es to @quill-next/delta-es