### PR TITLE
Copy implementation from MaciejDabek/quill:add-get-semantic-html-options

### DIFF
--- a/packages/quill/src/core/editor.ts
+++ b/packages/quill/src/core/editor.ts
@@ -16,6 +16,14 @@ type SelectionInfo = {
   oldRange: Range;
 };
 
+export type SemanticHTMLOptions = {
+  preserveWhitespace?: boolean;
+};
+
+const defaultSemanticHTMLOptions: SemanticHTMLOptions = {
+  preserveWhitespace: false,
+} as const;
+
 class Editor {
   scroll: Scroll;
   delta: Delta;
@@ -195,15 +203,20 @@ class Editor {
     return { ...lineFormats, ...leafFormats };
   }
 
-  getHTML(index: number, length: number): string {
+  getHTML(
+    index: number,
+    length: number,
+    options?: SemanticHTMLOptions,
+  ): string {
+    const finalOptions = { ...defaultSemanticHTMLOptions, ...options };
     const [line, lineOffset] = this.scroll.line(index);
     if (line) {
       const lineLength = line.length();
       const isWithinLine = line.length() >= lineOffset + length;
       if (isWithinLine && !(lineOffset === 0 && length === lineLength)) {
-        return convertHTML(line, lineOffset, length, true);
+        return convertHTML(line, lineOffset, length, finalOptions, true);
       }
-      return convertHTML(this.scroll, index, length, true);
+      return convertHTML(this.scroll, index, length, finalOptions, true);
     }
     return '';
   }
@@ -328,13 +341,14 @@ function convertListHTML(
   items: ListItem[],
   lastIndent: number,
   types: string[],
+  options: SemanticHTMLOptions,
 ): string {
   if (items.length === 0) {
     const [endTag] = getListType(types.pop());
     if (lastIndent <= 0) {
       return `</li></${endTag}>`;
     }
-    return `</li></${endTag}>${convertListHTML([], lastIndent - 1, types)}`;
+    return `</li></${endTag}>${convertListHTML([], lastIndent - 1, types, options)}`;
   }
   const [{ child, offset, length, indent, type }, ...rest] = items;
   const [tag, attribute] = getListType(type);
@@ -345,9 +359,10 @@ function convertListHTML(
         child,
         offset,
         length,
-      )}${convertListHTML(rest, indent, types)}`;
+        options,
+      )}${convertListHTML(rest, indent, types, options)}`;
     }
-    return `<${tag}><li>${convertListHTML(items, lastIndent + 1, types)}`;
+    return `<${tag}><li>${convertListHTML(items, lastIndent + 1, types, options)}`;
   }
   const previousType = types[types.length - 1];
   if (indent === lastIndent && type === previousType) {
@@ -355,16 +370,18 @@ function convertListHTML(
       child,
       offset,
       length,
-    )}${convertListHTML(rest, indent, types)}`;
+      options,
+    )}${convertListHTML(rest, indent, types, options)}`;
   }
   const [endTag] = getListType(types.pop());
-  return `</li></${endTag}>${convertListHTML(items, lastIndent - 1, types)}`;
+  return `</li></${endTag}>${convertListHTML(items, lastIndent - 1, types, options)}`;
 }
 
 function convertHTML(
   blot: Blot,
   index: number,
   length: number,
+  options: SemanticHTMLOptions,
   isRoot = false,
 ): string {
   if ('html' in blot && typeof blot.html === 'function') {
@@ -372,6 +389,7 @@ function convertHTML(
   }
   if (blot instanceof TextBlot) {
     const escapedText = escapeText(blot.value().slice(index, index + length));
+    if (options.preserveWhitespace) return escapedText;
     return escapedText.replaceAll(' ', '&nbsp;');
   }
   if (blot instanceof ParentBlot) {
@@ -391,11 +409,11 @@ function convertHTML(
           type: formats.list,
         });
       });
-      return convertListHTML(items, -1, []);
+      return convertListHTML(items, -1, [], options);
     }
     const parts: string[] = [];
     blot.children.forEachAt(index, length, (child, offset, childLength) => {
-      parts.push(convertHTML(child, offset, childLength));
+      parts.push(convertHTML(child, offset, childLength, options));
     });
     if (isRoot || blot.statics.blotName === 'list') {
       return parts.join('');

--- a/packages/quill/src/core/selection.ts
+++ b/packages/quill/src/core/selection.ts
@@ -35,6 +35,17 @@ export class Range {
   ) {}
 }
 
+export function isRange(value: any): value is Range {
+  return (
+    value &&
+    typeof value === 'object' &&
+    'index' in value &&
+    typeof value.index === 'number' &&
+    'length' in value &&
+    typeof value.length === 'number'
+  );
+}
+
 class Selection {
   scroll: Scroll;
   emitter: Emitter;

--- a/packages/quill/test/unit/core/editor.spec.ts
+++ b/packages/quill/test/unit/core/editor.spec.ts
@@ -1412,6 +1412,18 @@ describe('Editor', () => {
       expect(editor.getHTML(0, 5)).toEqual('<ul><li>Test</li></ul>');
     });
 
+    test('option preserveWhitespace is disabled (DEFAULT)', () => {
+      const editor = createEditor('<p>This is Quill</p>');
+      expect(editor.getHTML(0, 14)).toEqual('<p>This&nbsp;is&nbsp;Quill</p>');
+    });
+
+    test('option preserveWhitespace is enabled', () => {
+      const editor = createEditor('<p>This is Quill</p>');
+      expect(editor.getHTML(0, 14, { preserveWhitespace: true })).toEqual(
+        '<p>This is Quill</p>',
+      );
+    });
+
     test('across lines', () => {
       const editor = createEditor(
         '<h1 class="ql-align-center">Header</h1><p>Text</p><blockquote>Quote</blockquote>',

--- a/packages/quill/test/unit/core/quill.spec.ts
+++ b/packages/quill/test/unit/core/quill.spec.ts
@@ -605,9 +605,33 @@ describe('Quill', () => {
 
     test('works with range', () => {
       const quill = new Quill(createContainer('<h1>Welcome</h1>'));
-      expect(quill.getText({ index: 1, length: 2 })).toMatchInlineSnapshot(
-        '"el"',
-      );
+      expect(
+        quill.getSemanticHTML({ index: 1, length: 2 }),
+      ).toMatchInlineSnapshot('"el"');
+    });
+
+    test('works with only options', () => {
+      const quill = new Quill(createContainer('<h1>Welcome to quill</h1>'));
+      expect(quill.getSemanticHTML({ preserveWhitespace: true }))
+        .toMatchInlineSnapshot(`
+        "<h1>Welcome to quill</h1>"
+      `);
+    });
+
+    test('works with index and options', () => {
+      const quill = new Quill(createContainer('<h1>Welcome to quill</h1>'));
+      expect(quill.getSemanticHTML(0, { preserveWhitespace: true }))
+        .toMatchInlineSnapshot(`
+        "<h1>Welcome to quill</h1>"
+      `);
+    });
+
+    test('works with index, length and options', () => {
+      const quill = new Quill(createContainer('<h1>Welcome to quill</h1>'));
+      expect(quill.getSemanticHTML(0, 10, { preserveWhitespace: true }))
+        .toMatchInlineSnapshot(`
+        "Welcome to"
+      `);
     });
   });
 
@@ -1149,7 +1173,6 @@ describe('Quill', () => {
     });
 
     test('(range:range, dummy:number)', () => {
-      // @ts-expect-error
       const [index, length, formats, source] = overload(new Range(10, 1), 0);
       expect(index).toBe(10);
       expect(length).toBe(1);
@@ -1158,7 +1181,6 @@ describe('Quill', () => {
     });
 
     test('(range:range, dummy:number, format:string, value:boolean)', () => {
-      // @ts-expect-error
       const [index, length, formats, source] = overload(
         new Range(10, 1),
         0,
@@ -1172,7 +1194,6 @@ describe('Quill', () => {
     });
 
     test('(range:range, dummy:number, format:object, source:string)', () => {
-      // @ts-expect-error
       const [index, length, formats, source] = overload(
         new Range(10, 1),
         0,


### PR DESCRIPTION
Resolves issue #44 and includes all changes from #45 while also addressing the outstanding error preventing its merge.

MaciejDabek (https://github.com/slab/quill/pull/4598) created this wonderful implementation to address the &nbsp; replacement that was introduced in quill@2.0.3
