### PR TITLE
fix: port XSS security fixes for getSemanticHTML() from slab/quill PR #4774

### DIFF
--- a/packages/quill/src/core/editor.ts
+++ b/packages/quill/src/core/editor.ts
@@ -400,13 +400,22 @@ function convertHTML(
     if (isRoot || blot.statics.blotName === 'list') {
       return parts.join('');
     }
-    const { outerHTML, innerHTML } = blot.domNode as Element;
-    const [start, end] = outerHTML.split(`>${innerHTML}<`);
-    // TODO cleanup
-    if (start === '<table') {
-      return `<table style="border: 1px solid #000;">${parts.join('')}<${end}`;
+
+    const element = blot.domNode as Element;
+    const tagName = element.tagName.toLowerCase();
+    const attributes = Array.from(element.attributes)
+      .map((attr) => {
+        const safeName = attr.name.replace(/[^a-zA-Z0-9-_]/g, '');
+        return `${safeName}="${escapeText(attr.value)}"`;
+      })
+      .join(' ');
+
+    if (tagName === 'table') {
+      return `<table style="border: 1px solid #000;">${parts.join('')}</table>`;
     }
-    return `${start}>${parts.join('')}<${end}`;
+
+    const openTag = attributes ? `<${tagName} ${attributes}>` : `<${tagName}>`;
+    return `${openTag}${parts.join('')}</${tagName}>`;
   }
   return blot.domNode instanceof Element ? blot.domNode.outerHTML : '';
 }

--- a/packages/quill/src/formats/formula.ts
+++ b/packages/quill/src/formats/formula.ts
@@ -1,4 +1,5 @@
 import Embed from '../blots/embed.js';
+import { escapeText } from '../blots/text.js';
 
 class Formula extends Embed {
   static blotName = 'formula';
@@ -26,9 +27,11 @@ class Formula extends Embed {
     return domNode.getAttribute('data-value');
   }
 
+  domNode: HTMLElement;
+
   html() {
-    const { formula } = this.value();
-    return `<span>${formula}</span>`;
+    const formula = Formula.value(this.domNode) || '';
+    return `<span>${escapeText(formula)}</span>`;
   }
 }
 

--- a/packages/quill/src/formats/image.ts
+++ b/packages/quill/src/formats/image.ts
@@ -1,5 +1,6 @@
 import { EmbedBlot } from 'parchment';
 import { sanitize } from './link.js';
+import { escapeText } from '../blots/text.js';
 
 const ATTRIBUTES = ['alt', 'height', 'width'];
 
@@ -51,6 +52,25 @@ class Image extends EmbedBlot {
     } else {
       super.format(name, value);
     }
+  }
+
+  html() {
+    const { src, alt, width, height } = this.domNode;
+    const sanitizedSrc = Image.sanitize(src);
+    const sanitizedAlt = alt ? escapeText(alt) : '';
+
+    let attributes = `src="${escapeText(sanitizedSrc)}"`;
+    if (sanitizedAlt) {
+      attributes += ` alt="${sanitizedAlt}"`;
+    }
+    if (width) {
+      attributes += ` width="${escapeText(String(width))}"`;
+    }
+    if (height) {
+      attributes += ` height="${escapeText(String(height))}"`;
+    }
+
+    return `<img ${attributes}>`;
   }
 }
 

--- a/packages/quill/src/formats/link.ts
+++ b/packages/quill/src/formats/link.ts
@@ -33,7 +33,8 @@ class Link extends Inline {
   }
 
   html(index: number, length: number) {
-    const href = Link.sanitize(this.domNode.getAttribute('href') || '');
+    const LinkClass = this.constructor as typeof Link;
+    const href = LinkClass.sanitize(this.domNode.getAttribute('href') || '');
     const rel = this.domNode.getAttribute('rel');
     const target = this.domNode.getAttribute('target');
 

--- a/packages/quill/src/formats/link.ts
+++ b/packages/quill/src/formats/link.ts
@@ -1,4 +1,5 @@
 import Inline from '../blots/inline.js';
+import { escapeText } from '../blots/text.js';
 
 class Link extends Inline {
   static blotName = 'link';
@@ -29,6 +30,33 @@ class Link extends Inline {
       // @ts-expect-error
       this.domNode.setAttribute('href', this.constructor.sanitize(value));
     }
+  }
+
+  html(index: number, length: number) {
+    const href = Link.sanitize(this.domNode.getAttribute('href') || '');
+    const rel = this.domNode.getAttribute('rel');
+    const target = this.domNode.getAttribute('target');
+
+    let attrs = `href="${escapeText(href)}"`;
+    if (rel) attrs += ` rel="${escapeText(rel)}"`;
+    if (target) attrs += ` target="${escapeText(target)}"`;
+
+    const parts: string[] = [];
+    this.children.forEachAt(index, length, (child, offset, childLength) => {
+      if ('html' in child && typeof child.html === 'function') {
+        parts.push(child.html(offset, childLength));
+      } else if ('value' in child && typeof child.value === 'function') {
+        parts.push(
+          escapeText(
+            (child.value() as string).slice(offset, offset + childLength),
+          ).replaceAll(' ', '&nbsp;'),
+        );
+      } else {
+        parts.push((child.domNode as Element).outerHTML);
+      }
+    });
+
+    return `<a ${attrs}>${parts.join('')}</a>`;
   }
 }
 

--- a/packages/quill/src/formats/video.ts
+++ b/packages/quill/src/formats/video.ts
@@ -1,4 +1,5 @@
 import { BlockEmbed } from '../blots/block.js';
+import { escapeText } from '../blots/text.js';
 import Link from './link.js';
 
 const ATTRIBUTES = ['height', 'width'];
@@ -51,8 +52,8 @@ class Video extends BlockEmbed {
   }
 
   html() {
-    const { video } = this.value();
-    return `<a href="${video}">${video}</a>`;
+    const video = Video.value(this.domNode) || '';
+    return `<a href="${escapeText(video)}">${escapeText(video)}</a>`;
   }
 }
 

--- a/packages/quill/src/formats/video.ts
+++ b/packages/quill/src/formats/video.ts
@@ -52,7 +52,7 @@ class Video extends BlockEmbed {
   }
 
   html() {
-    const video = Video.value(this.domNode) || '';
+    const video = Video.sanitize(Video.value(this.domNode) || '');
     return `<a href="${escapeText(video)}">${escapeText(video)}</a>`;
   }
 }

--- a/packages/quill/src/modules/syntax.ts
+++ b/packages/quill/src/modules/syntax.ts
@@ -159,7 +159,7 @@ class SyntaxCodeBlockContainer extends CodeBlockContainer {
       ? SyntaxCodeBlock.formats(codeBlock.domNode)
       : 'plain';
 
-    return `<pre data-language="${language}">\n${escapeText(
+    return `<pre data-language="${escapeText(language)}">\n${escapeText(
       this.code(index, length),
     )}\n</pre>`;
   }

--- a/packages/quill/src/themes/snow.ts
+++ b/packages/quill/src/themes/snow.ts
@@ -66,10 +66,11 @@ class SnowTooltip extends BaseTooltip {
           if (link != null) {
             this.linkRange = new Range(range.index - offset, link.length());
             const preview = LinkBlot.formats(link.domNode);
+            const sanitizedPreview = preview ? LinkBlot.sanitize(preview) : '';
             // @ts-expect-error Fix me later
-            this.preview.textContent = preview;
+            this.preview.textContent = sanitizedPreview;
             // @ts-expect-error Fix me later
-            this.preview.setAttribute('href', preview);
+            this.preview.setAttribute('href', sanitizedPreview);
             this.show();
             const bounds = this.quill.getBounds(this.linkRange);
             if (bounds != null) {

--- a/packages/quill/test/unit/core/editor-xss.spec.ts
+++ b/packages/quill/test/unit/core/editor-xss.spec.ts
@@ -1,0 +1,190 @@
+import { describe, expect, test } from 'vitest';
+import { createRegistry } from '../__helpers__/factory.js';
+import Quill from '../../../src/core.js';
+import { normalizeHTML } from '../__helpers__/utils.js';
+import List, { ListContainer } from '../../../src/formats/list.js';
+import Bold from '../../../src/formats/bold.js';
+import Link from '../../../src/formats/link.js';
+import Italic from '../../../src/formats/italic.js';
+
+const createEditor = (htmlOrContents: string) => {
+  const container = document.createElement('div');
+  container.innerHTML = normalizeHTML(htmlOrContents);
+  document.body.appendChild(container);
+  const quill = new Quill(container, {
+    registry: createRegistry([ListContainer, List, Bold, Link, Italic]),
+  });
+  return quill.editor;
+};
+
+describe('Editor XSS Prevention (convertHTML)', () => {
+  describe('Attribute Escaping', () => {
+    test('escapes quotes in element attributes', () => {
+      const editor = createEditor(
+        '<p><a href="https://example.com&quot; onclick=&quot;alert(1)">Link</a></p>',
+      );
+      const html = editor.getHTML(0, 5);
+
+      // Should escape quotes to prevent attribute injection
+      expect(html).toContain('&quot;');
+      // Should NOT allow onclick attribute injection
+      expect(html).not.toContain('" onclick="');
+    });
+
+    test('escapes ampersands in attributes', () => {
+      const editor = createEditor(
+        '<p><a href="https://example.com?a=1&amp;b=2">Link</a></p>',
+      );
+      const html = editor.getHTML(0, 5);
+
+      // Should preserve escaped ampersands
+      expect(html).toContain('&amp;');
+    });
+
+    test('escapes less than and greater than in attributes', () => {
+      const editor = createEditor(
+        '<p><a href="https://example.com?val=&lt;test&gt;">Link</a></p>',
+      );
+      const html = editor.getHTML(0, 5);
+
+      // Should escape < and >
+      expect(html).toContain('&lt;');
+      expect(html).toContain('&gt;');
+    });
+
+    test('prevents script injection via attributes', () => {
+      const editor = createEditor(
+        '<p><a href="&lt;script&gt;alert(1)&lt;/script&gt;">Link</a></p>',
+      );
+      const html = editor.getHTML(0, 5);
+
+      // Should NOT contain unescaped script tags
+      expect(html).not.toContain('<script>');
+      // Should contain escaped version
+      expect(html).toContain('&lt;script&gt;');
+    });
+  });
+
+  describe('Unsafe outerHTML.split() Protection', () => {
+    test('handles attributes containing ">innerHTML<" pattern', () => {
+      const editor = createEditor(
+        '<p><a href="https://example.com?param=&gt;test&lt;">Link</a></p>',
+      );
+      const html = editor.getHTML(0, 5);
+
+      // Should produce well-formed HTML without structure corruption
+      expect(html).toContain('<a href=');
+      expect(html).toContain('>Link</a>');
+      // Should escape the special characters
+      expect(html).toContain('&gt;');
+      expect(html).toContain('&lt;');
+    });
+
+    test('handles complex nested attributes', () => {
+      const editor = createEditor(
+        '<ul><li><strong>Bold</strong> and <em>italic</em></li></ul>',
+      );
+      const html = editor.getHTML(0, 18);
+
+      // Should maintain proper HTML structure
+      expect(html).toContain('<ul>');
+      expect(html).toContain('<li>');
+      expect(html).toContain('<strong>');
+      expect(html).toContain('<em>');
+      expect(html).toContain('</em>');
+      expect(html).toContain('</strong>');
+      expect(html).toContain('</li>');
+      expect(html).toContain('</ul>');
+    });
+
+    test('preserves multiple attributes safely', () => {
+      const editor = createEditor(
+        '<p><a href="https://example.com" class="ql-link" target="_blank">Test</a></p>',
+      );
+      const html = editor.getHTML(0, 5);
+
+      // Should escape all attribute values
+      // Note: class and target might not be in final output depending on format definition
+      // but if they are, they should be escaped
+      expect(html).not.toContain('" onclick="');
+      expect(html).not.toContain('" onload="');
+    });
+  });
+
+  describe('Special Characters in Content', () => {
+    test('escapes HTML entities in text content', () => {
+      const editor = createEditor(
+        '<p>&lt;script&gt;alert(1)&lt;/script&gt;</p>',
+      );
+      const html = editor.getHTML(0, 28);
+
+      // Should keep entities escaped
+      expect(html).not.toContain('<script>');
+      expect(html).toContain('&lt;script&gt;');
+    });
+
+    test('handles mixed content with special characters', () => {
+      const editor = createEditor(
+        '<p><strong>A &amp; B &lt; C &gt; D &quot;E&quot;</strong></p>',
+      );
+      const html = editor.getHTML(0, 20);
+
+      // Should preserve all escaping
+      expect(html).toContain('&amp;');
+      expect(html).toContain('&lt;');
+      expect(html).toContain('&gt;');
+      expect(html).toContain('&quot;');
+    });
+  });
+
+  describe('Link Format Safety', () => {
+    test('sanitizes javascript: protocol in links', () => {
+      const container = document.createElement('div');
+      container.innerHTML = '<p><a href="javascript:alert(1)">Click</a></p>';
+      document.body.appendChild(container);
+      const quill = new Quill(container, {
+        registry: createRegistry([Link]),
+      });
+      const html = quill.editor.getHTML(0, 6);
+
+      // Should sanitize the protocol
+      expect(html).not.toContain('javascript:');
+    });
+
+    test('allows safe protocols in links', () => {
+      const editor = createEditor(
+        '<p><a href="https://example.com">Link</a></p>',
+      );
+      const html = editor.getHTML(0, 5);
+
+      // Should preserve safe https protocol
+      expect(html).toContain('https://example.com');
+    });
+  });
+
+  describe('List and Complex Structure Safety', () => {
+    test('escapes attributes in list elements', () => {
+      const editor = createEditor('<ul><li>Item</li></ul>');
+      const html = editor.getHTML(0, 5);
+
+      // Should maintain valid list structure
+      expect(html).toContain('<ul>');
+      expect(html).toContain('<li>');
+      expect(html).toContain('</li>');
+      expect(html).toContain('</ul>');
+      // Should NOT allow attribute injection
+      expect(html).not.toContain('" onclick="');
+    });
+
+    test('safely handles nested lists with attributes', () => {
+      const editor = createEditor('<ol><li>One</li><li>Two</li></ol>');
+      const html = editor.getHTML(0, 9);
+
+      // Should produce valid nested structure
+      expect(html).toContain('<ol>');
+      expect(html).toContain('<li>');
+      expect(html).toContain('</li>');
+      expect(html).toContain('</ol>');
+    });
+  });
+});

--- a/packages/quill/test/unit/formats/formula.spec.ts
+++ b/packages/quill/test/unit/formats/formula.spec.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test, beforeAll } from 'vitest';
+import {
+  createScroll as baseCreateScroll,
+  createRegistry,
+} from '../__helpers__/factory.js';
+import Editor from '../../../src/core/editor.js';
+import Formula from '../../../src/formats/formula.js';
+
+const createScroll = (html: string) =>
+  baseCreateScroll(html, createRegistry([Formula]));
+
+describe('Formula', () => {
+  // Mock KaTeX for tests
+  beforeAll(() => {
+    // @ts-expect-error - Mocking global
+    window.katex = {
+      render: () => {
+        // Mock render function
+      },
+    };
+  });
+
+  describe('XSS Prevention', () => {
+    test('escapes HTML tags in formula', () => {
+      const editor = new Editor(createScroll('<p><br></p>'));
+      const malicious = '<script>alert(1)</script>';
+      editor.insertEmbed(0, 'formula', malicious);
+      const html = editor.getHTML(0, 2);
+
+      // Should NOT contain unescaped HTML
+      expect(html).not.toContain('<script>');
+      expect(html).not.toContain('</script>');
+
+      // Should contain escaped version
+      expect(html).toContain('&lt;script&gt;');
+      expect(html).toContain('&lt;/script&gt;');
+    });
+
+    test('escapes malicious closing tags', () => {
+      const editor = new Editor(createScroll('<p><br></p>'));
+      const malicious = '</span><img src=x onerror=alert(1)>';
+      editor.insertEmbed(0, 'formula', malicious);
+      const html = editor.getHTML(0, 2);
+
+      // Should NOT contain unescaped closing tag or img tag
+      expect(html).not.toContain('</span><img');
+      // Should not have the img tag with onerror attribute (even if words appear escaped)
+      expect(html).not.toContain('<img');
+
+      // Should contain escaped version
+      expect(html).toContain('&lt;/span&gt;');
+      expect(html).toContain('&lt;img');
+    });
+
+    test('escapes quotes in formula', () => {
+      const editor = new Editor(createScroll('<p><br></p>'));
+      const malicious = '" onload="alert(1)';
+      editor.insertEmbed(0, 'formula', malicious);
+      const html = editor.getHTML(0, 2);
+
+      // Should contain escaped quotes
+      expect(html).toContain('&quot;');
+      // The word "onload" might appear but should be escaped, prevent the actual exploit
+      expect(html).not.toContain('" onload="');
+    });
+
+    test('escapes ampersands in formula', () => {
+      const editor = new Editor(createScroll('<p><br></p>'));
+      const formula = 'a & b';
+      editor.insertEmbed(0, 'formula', formula);
+      const html = editor.getHTML(0, 2);
+
+      // Should contain escaped ampersand
+      expect(html).toContain('&amp;');
+    });
+
+    test('escapes less than and greater than operators', () => {
+      const editor = new Editor(createScroll('<p><br></p>'));
+      const formula = 'x < 5 && y > 3';
+      editor.insertEmbed(0, 'formula', formula);
+      const html = editor.getHTML(0, 2);
+
+      // Should contain escaped operators (this also fixes invalid HTML)
+      expect(html).toContain('&lt;');
+      expect(html).toContain('&gt;');
+      expect(html).toContain('&amp;&amp;');
+    });
+
+    test('handles normal formulas without special characters', () => {
+      const editor = new Editor(createScroll('<p><br></p>'));
+      const formula = 'E=mc^2';
+      editor.insertEmbed(0, 'formula', formula);
+      const html = editor.getHTML(0, 2);
+
+      // Should contain the formula as-is (no special chars to escape)
+      expect(html).toContain('E=mc^2');
+    });
+
+    test('handles empty formula', () => {
+      const editor = new Editor(createScroll('<p><br></p>'));
+      editor.insertEmbed(0, 'formula', '');
+      const html = editor.getHTML(0, 2);
+
+      // Should create valid HTML even with empty formula
+      expect(html).toContain('<span></span>');
+    });
+
+    test('prevents double-escaping of already-escaped content', () => {
+      const editor = new Editor(createScroll('<p><br></p>'));
+      // User explicitly enters escaped content
+      const alreadyEscaped = '&lt;script&gt;';
+      editor.insertEmbed(0, 'formula', alreadyEscaped);
+      const html = editor.getHTML(0, 2);
+
+      // Should double-escape (correct behavior - user wanted literal text)
+      expect(html).toContain('&amp;lt;script&amp;gt;');
+    });
+  });
+});

--- a/packages/quill/test/unit/formats/image.spec.ts
+++ b/packages/quill/test/unit/formats/image.spec.ts
@@ -1,0 +1,215 @@
+import { describe, expect, test } from 'vitest';
+import {
+  createScroll as baseCreateScroll,
+  createRegistry,
+} from '../__helpers__/factory.js';
+import Editor from '../../../src/core/editor.js';
+import Image from '../../../src/formats/image.js';
+
+const createScroll = (html: string) =>
+  baseCreateScroll(html, createRegistry([Image]));
+
+describe('Image', () => {
+  describe('XSS Prevention', () => {
+    test('prevents onerror attribute injection', () => {
+      // This is the critical vulnerability: img tags with onerror handlers
+      const scroll = createScroll('<p><img src="x" onerror="alert(1)"></p>');
+      const imageEditor = new Editor(scroll);
+      const html = imageEditor.getHTML(0, 2);
+
+      // Should NOT contain the onerror attribute
+      expect(html).not.toContain('onerror');
+      expect(html).not.toContain('alert(1)');
+      expect(html).not.toContain('alert');
+
+      // Should only contain safe attributes
+      expect(html).toContain('<img');
+      expect(html).toContain('src=');
+    });
+
+    test('prevents onclick attribute injection', () => {
+      const scroll = createScroll(
+        '<p><img src="valid.jpg" onclick="alert(1)"></p>',
+      );
+      const editor = new Editor(scroll);
+      const html = editor.getHTML(0, 2);
+
+      // Should NOT contain the onclick attribute
+      expect(html).not.toContain('onclick');
+      expect(html).not.toContain('alert');
+    });
+
+    test('prevents onload attribute injection', () => {
+      const scroll = createScroll(
+        '<p><img src="valid.jpg" onload="alert(1)"></p>',
+      );
+      const editor = new Editor(scroll);
+      const html = editor.getHTML(0, 2);
+
+      // Should NOT contain the onload attribute
+      expect(html).not.toContain('onload');
+      expect(html).not.toContain('alert');
+    });
+
+    test('escapes quotes in alt attribute', () => {
+      const scroll = createScroll(
+        '<p><img src="valid.jpg" alt="test&quot; onerror=&quot;alert(1)"></p>',
+      );
+      const editor = new Editor(scroll);
+      const html = editor.getHTML(0, 2);
+
+      // Should contain escaped quotes
+      expect(html).toContain('&quot;');
+      // Should NOT allow attribute injection
+      expect(html).not.toContain('" onerror="');
+    });
+
+    test('escapes HTML in alt attribute', () => {
+      const scroll = createScroll(
+        '<p><img src="valid.jpg" alt="&lt;script&gt;alert(1)&lt;/script&gt;"></p>',
+      );
+      const editor = new Editor(scroll);
+      const html = editor.getHTML(0, 2);
+
+      // Should contain double-escaped content (escaped once in DOM, escaped again in output)
+      expect(html).not.toContain('<script>');
+      expect(html).toContain('&lt;');
+    });
+
+    test('escapes special characters in width attribute', () => {
+      const scroll = createScroll('<p><img src="valid.jpg" width="100"></p>');
+      const editor = new Editor(scroll);
+      const html = editor.getHTML(0, 2);
+
+      // Should contain width properly
+      expect(html).toContain('width="100"');
+      // Should NOT allow attribute injection
+      expect(html).not.toContain('" onload="');
+    });
+
+    test('escapes special characters in height attribute', () => {
+      const scroll = createScroll('<p><img src="valid.jpg" height="100"></p>');
+      const editor = new Editor(scroll);
+      const html = editor.getHTML(0, 2);
+
+      // Should contain height properly
+      expect(html).toContain('height="100"');
+      // Should NOT allow attribute injection
+      expect(html).not.toContain('" onclick="');
+    });
+
+    test('sanitizes malicious src URL', () => {
+      const scroll = createScroll('<p><img src="javascript:alert(1)"></p>');
+      const editor = new Editor(scroll);
+      const html = editor.getHTML(0, 2);
+
+      // Should sanitize javascript: protocol
+      expect(html).not.toContain('javascript:');
+      // Should fall back to safe URL
+      expect(html).toContain('src="//:0"');
+    });
+
+    test('handles URL-encoded characters in src', () => {
+      const scroll = createScroll(
+        '<p><img src="valid.jpg%22%20onerror=%22alert(1)"></p>',
+      );
+      const editor = new Editor(scroll);
+      const html = editor.getHTML(0, 2);
+
+      // URL encoding prevents injection - the src is treated as one value
+      expect(html).toContain('src=');
+      // Should NOT create malformed HTML with executable onerror
+      expect(html).not.toContain('" onerror="');
+      // The % characters indicate URL encoding happened
+      expect(html).toContain('%');
+    });
+
+    test('handles ampersands in src URL', () => {
+      const scroll = createScroll(
+        '<p><img src="https://example.com/img?a=1&amp;b=2"></p>',
+      );
+      const editor = new Editor(scroll);
+      const html = editor.getHTML(0, 2);
+
+      // Should preserve escaped ampersand
+      expect(html).toContain('&amp;');
+    });
+
+    test('handles normal image with safe attributes', () => {
+      const scroll = createScroll(
+        '<p><img src="https://example.com/image.jpg" alt="Test Image" width="100" height="200"></p>',
+      );
+      const editor = new Editor(scroll);
+      const html = editor.getHTML(0, 2);
+
+      // Should contain all safe attributes
+      expect(html).toContain('src="https://example.com/image.jpg"');
+      expect(html).toContain('alt="Test Image"');
+      expect(html).toContain('width="100"');
+      expect(html).toContain('height="200"');
+    });
+
+    test('handles image with empty alt', () => {
+      const scroll = createScroll('<p><img src="valid.jpg"></p>');
+      const editor = new Editor(scroll);
+      const html = editor.getHTML(0, 2);
+
+      // Should create valid HTML without alt if not present
+      expect(html).toContain('<img');
+      expect(html).toContain('src=');
+    });
+
+    test('prevents data attribute injection', () => {
+      const scroll = createScroll(
+        '<p><img src="valid.jpg" data-evil="alert(1)"></p>',
+      );
+      const editor = new Editor(scroll);
+      const html = editor.getHTML(0, 2);
+
+      // Should NOT contain data attributes (not in ATTRIBUTES whitelist)
+      expect(html).not.toContain('data-evil');
+    });
+
+    test('prevents style attribute injection', () => {
+      const scroll = createScroll(
+        '<p><img src="valid.jpg" style="background:url(javascript:alert(1))"></p>',
+      );
+      const editor = new Editor(scroll);
+      const html = editor.getHTML(0, 2);
+
+      // Should NOT contain style attribute (not in ATTRIBUTES whitelist)
+      expect(html).not.toContain('style=');
+      expect(html).not.toContain('javascript:');
+    });
+
+    test('prevents class attribute injection', () => {
+      const scroll = createScroll(
+        '<p><img src="valid.jpg" class="malicious"></p>',
+      );
+      const editor = new Editor(scroll);
+      const html = editor.getHTML(0, 2);
+
+      // Should NOT contain class attribute (not in ATTRIBUTES whitelist)
+      expect(html).not.toContain('class=');
+    });
+
+    test('only includes whitelisted attributes', () => {
+      const scroll = createScroll(
+        '<p><img src="valid.jpg" alt="test" width="100" height="200" id="img1" name="myimg" title="tooltip"></p>',
+      );
+      const editor = new Editor(scroll);
+      const html = editor.getHTML(0, 2);
+
+      // Should include whitelisted attributes: src, alt, width, height
+      expect(html).toContain('src=');
+      expect(html).toContain('alt=');
+      expect(html).toContain('width=');
+      expect(html).toContain('height=');
+
+      // Should NOT include non-whitelisted attributes: id, name, title
+      expect(html).not.toContain('id=');
+      expect(html).not.toContain('name=');
+      expect(html).not.toContain('title=');
+    });
+  });
+});

--- a/packages/quill/test/unit/formats/link.spec.ts
+++ b/packages/quill/test/unit/formats/link.spec.ts
@@ -86,3 +86,121 @@ describe('Link', () => {
     );
   });
 });
+
+describe('Link XSS Prevention (getSemanticHTML)', () => {
+  test('sanitizes javascript: protocol injected after insertion', () => {
+    const editor = new Editor(createScroll('<p>0123</p>'));
+    editor.formatText(1, 2, { link: 'https://safe.com' });
+
+    // Simulate post-insertion DOM manipulation (e.g., via Yjs collaborative sync)
+    const anchor = editor.scroll.domNode.querySelector('a')!;
+    anchor.setAttribute('href', 'javascript:alert(document.cookie)'); // eslint-disable-line no-script-url
+
+    const html = editor.getHTML(0, 4);
+
+    // Should NOT export dangerous protocol
+    expect(html).not.toContain('javascript:');
+    // Should fall back to about:blank
+    expect(html).toContain('href="about:blank"');
+  });
+
+  test('sanitizes data: protocol injected after insertion', () => {
+    const editor = new Editor(createScroll('<p>click</p>'));
+    editor.formatText(0, 5, { link: 'https://safe.com' });
+
+    const anchor = editor.scroll.domNode.querySelector('a')!;
+    anchor.setAttribute('href', 'data:text/html,<script>alert(1)</script>');
+
+    const html = editor.getHTML(0, 5);
+
+    expect(html).not.toContain('data:text/html');
+    expect(html).toContain('href="about:blank"');
+  });
+
+  test('sanitizes vbscript: protocol injected after insertion', () => {
+    const editor = new Editor(createScroll('<p>click</p>'));
+    editor.formatText(0, 5, { link: 'https://safe.com' });
+
+    const anchor = editor.scroll.domNode.querySelector('a')!;
+    anchor.setAttribute('href', 'vbscript:MsgBox(1)');
+
+    const html = editor.getHTML(0, 5);
+
+    expect(html).not.toContain('vbscript:');
+    expect(html).toContain('href="about:blank"');
+  });
+
+  test('preserves safe http: links unchanged', () => {
+    const editor = new Editor(createScroll('<p>link</p>'));
+    editor.formatText(0, 4, { link: 'http://example.com/path?a=1&b=2' });
+
+    const html = editor.getHTML(0, 4);
+
+    expect(html).toContain('href="http://example.com/path?a=1&amp;b=2"');
+    expect(html).not.toContain('javascript:');
+  });
+
+  test('preserves safe https: links unchanged', () => {
+    const editor = new Editor(createScroll('<p>link</p>'));
+    editor.formatText(0, 4, { link: 'https://quilljs.com' });
+
+    const html = editor.getHTML(0, 4);
+
+    expect(html).toContain('href="https://quilljs.com"');
+  });
+
+  test('preserves mailto: links unchanged', () => {
+    const editor = new Editor(createScroll('<p>email</p>'));
+    editor.formatText(0, 5, { link: 'mailto:user@example.com' });
+
+    const html = editor.getHTML(0, 5);
+
+    expect(html).toContain('href="mailto:user@example.com"');
+  });
+
+  test('escapes special characters in href attribute value', () => {
+    const editor = new Editor(createScroll('<p>link</p>'));
+    editor.formatText(0, 4, { link: 'https://example.com?a=1&b=<2>' });
+
+    const html = editor.getHTML(0, 4);
+
+    // & and < must be HTML-entity-escaped inside an attribute
+    expect(html).toContain('&amp;');
+    expect(html).toContain('&lt;');
+    expect(html).not.toContain('href="https://example.com?a=1&b=<2>"');
+  });
+
+  test('escapes quotes injected into href to prevent attribute breakout', () => {
+    const editor = new Editor(createScroll('<p>link</p>'));
+    editor.formatText(0, 4, { link: 'https://safe.com' });
+
+    const anchor = editor.scroll.domNode.querySelector('a')!;
+    anchor.setAttribute('href', 'https://safe.com" onclick="alert(1)');
+
+    const html = editor.getHTML(0, 4);
+
+    expect(html).not.toContain('" onclick="');
+    expect(html).toContain('&quot;');
+  });
+
+  test('includes rel and target attributes safely', () => {
+    const editor = new Editor(createScroll('<p>link</p>'));
+    editor.formatText(0, 4, { link: 'https://example.com' });
+
+    const html = editor.getHTML(0, 4);
+
+    expect(html).toContain('rel="noopener noreferrer"');
+    expect(html).toContain('target="_blank"');
+  });
+
+  test('renders link text content safely (not innerHTML)', () => {
+    const editor = new Editor(createScroll('<p>click here</p>'));
+    editor.formatText(0, 10, { link: 'https://example.com' });
+
+    const html = editor.getHTML(0, 10);
+
+    // Link text should be present and safely rendered
+    expect(html).toContain('>click&nbsp;here</a>');
+    expect(html).toContain('href="https://example.com"');
+  });
+});

--- a/packages/quill/test/unit/formats/video.spec.ts
+++ b/packages/quill/test/unit/formats/video.spec.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from 'vitest';
+import {
+  createScroll as baseCreateScroll,
+  createRegistry,
+} from '../__helpers__/factory.js';
+import Editor from '../../../src/core/editor.js';
+import Video from '../../../src/formats/video.js';
+
+const createScroll = (html: string) =>
+  baseCreateScroll(html, createRegistry([Video]));
+
+describe('Video', () => {
+  describe('XSS Prevention', () => {
+    test('escapes HTML tags in video URL', () => {
+      const editor = new Editor(createScroll('<p><br></p>'));
+      const malicious = '<script>alert(1)</script>';
+      editor.insertEmbed(0, 'video', malicious);
+      const html = editor.getHTML(0, 2);
+
+      // Should NOT contain unescaped HTML
+      expect(html).not.toContain('<script>');
+      expect(html).not.toContain('</script>');
+
+      // Should contain escaped version
+      expect(html).toContain('&lt;script&gt;');
+      expect(html).toContain('&lt;/script&gt;');
+    });
+
+    test('escapes malicious attributes in video URL', () => {
+      const editor = new Editor(createScroll('<p><br></p>'));
+      const malicious = '"><script>alert(1)</script><a href="';
+      editor.insertEmbed(0, 'video', malicious);
+      const html = editor.getHTML(0, 2);
+
+      // Should NOT contain unescaped script tag
+      expect(html).not.toContain('<script>');
+
+      // Should contain escaped version
+      expect(html).toContain('&lt;script&gt;');
+    });
+
+    test('escapes quotes in video URL', () => {
+      const editor = new Editor(createScroll('<p><br></p>'));
+      const malicious = '" onclick="alert(1)';
+      editor.insertEmbed(0, 'video', malicious);
+      const html = editor.getHTML(0, 2);
+
+      // Should contain escaped quotes
+      expect(html).toContain('&quot;');
+      // The word "onclick" will still appear but in escaped form
+      // What matters is the quotes are escaped, preventing attribute injection
+      expect(html).not.toContain('" onclick="');
+    });
+
+    test('escapes ampersands in video URL', () => {
+      const editor = new Editor(createScroll('<p><br></p>'));
+      const url = 'https://example.com?a=1&b=2';
+      editor.insertEmbed(0, 'video', url);
+      const html = editor.getHTML(0, 2);
+
+      // Should contain escaped ampersand in both href and text
+      expect(html).toContain('&amp;');
+    });
+
+    test('sanitizes dangerous protocol injected after insertion', () => {
+      const editor = new Editor(createScroll('<p><br></p>'));
+      editor.insertEmbed(0, 'video', 'https://safe.example/video');
+
+      const iframe = editor.scroll.domNode.querySelector('iframe')!;
+      iframe.setAttribute('src', 'javascript:alert(1)'); // eslint-disable-line no-script-url
+
+      const html = editor.getHTML(0, 2);
+
+      expect(html).not.toContain('javascript:');
+      expect(html).toContain('href="about:blank"');
+    });
+
+    test('handles normal video URLs', () => {
+      const editor = new Editor(createScroll('<p><br></p>'));
+      const url = 'https://youtube.com/watch?v=abc123';
+      editor.insertEmbed(0, 'video', url);
+      const html = editor.getHTML(0, 2);
+
+      // Should contain the URL
+      expect(html).toContain('youtube.com/watch');
+    });
+
+    test('handles empty video URL', () => {
+      const editor = new Editor(createScroll('<p><br></p>'));
+      editor.insertEmbed(0, 'video', '');
+      const html = editor.getHTML(0, 2);
+
+      // Should create valid HTML even with empty URL
+      expect(html).toContain('<a href=""></a>');
+    });
+  });
+});

--- a/packages/quill/test/unit/modules/syntax.spec.ts
+++ b/packages/quill/test/unit/modules/syntax.spec.ts
@@ -292,4 +292,152 @@ describe('Syntax', () => {
       expect(quill.getSemanticHTML()).toContain('data-language="javascript"');
     });
   });
+
+  describe('XSS Prevention', () => {
+    test('escapes quotes in data-language attribute', () => {
+      const container = document.body.appendChild(
+        document.createElement('div'),
+      );
+      container.innerHTML = normalizeHTML(
+        `<pre data-language="test&quot; onclick=&quot;alert(1)"><br></pre>`,
+      );
+      const quill = new Quill(container, {
+        modules: {
+          syntax: {
+            hljs,
+            interval: HIGHLIGHT_INTERVAL,
+          },
+        },
+        registry: createRegistry([
+          CodeToken,
+          CodeBlock,
+          Quill.import('formats/code-block-container'),
+        ]),
+      });
+      const html = quill.getSemanticHTML();
+
+      // Should escape quotes
+      expect(html).toContain('&quot;');
+      // Should NOT allow attribute injection
+      expect(html).not.toContain('" onclick="');
+    });
+
+    test('escapes malicious language closing tag', () => {
+      const container = document.body.appendChild(
+        document.createElement('div'),
+      );
+      container.innerHTML = normalizeHTML(
+        `<pre data-language="&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;&lt;pre x=&quot;"><br></pre>`,
+      );
+      const quill = new Quill(container, {
+        modules: {
+          syntax: {
+            hljs,
+            interval: HIGHLIGHT_INTERVAL,
+          },
+        },
+        registry: createRegistry([
+          CodeToken,
+          CodeBlock,
+          Quill.import('formats/code-block-container'),
+        ]),
+      });
+      const html = quill.getSemanticHTML();
+
+      // Should NOT contain unescaped script tags
+      expect(html).not.toContain('<script>');
+      // Should contain escaped version
+      expect(html).toContain('&lt;script&gt;');
+    });
+
+    test('escapes ampersands in language attribute', () => {
+      const container = document.body.appendChild(
+        document.createElement('div'),
+      );
+      container.innerHTML = normalizeHTML(
+        `<pre data-language="cpp&amp;test"><br></pre>`,
+      );
+      const quill = new Quill(container, {
+        modules: {
+          syntax: {
+            hljs,
+            interval: HIGHLIGHT_INTERVAL,
+          },
+        },
+        registry: createRegistry([
+          CodeToken,
+          CodeBlock,
+          Quill.import('formats/code-block-container'),
+        ]),
+      });
+      const html = quill.getSemanticHTML();
+
+      // Should preserve escaped ampersand
+      expect(html).toContain('&amp;');
+    });
+
+    test('escapes less than and greater than in language', () => {
+      const container = document.body.appendChild(
+        document.createElement('div'),
+      );
+      container.innerHTML = normalizeHTML(
+        `<pre data-language="&lt;test&gt;"><br></pre>`,
+      );
+      const quill = new Quill(container, {
+        modules: {
+          syntax: {
+            hljs,
+            interval: HIGHLIGHT_INTERVAL,
+          },
+        },
+        registry: createRegistry([
+          CodeToken,
+          CodeBlock,
+          Quill.import('formats/code-block-container'),
+        ]),
+      });
+      const html = quill.getSemanticHTML();
+
+      // Should escape < and >
+      expect(html).toContain('&lt;test&gt;');
+    });
+
+    test('prevents attribute injection via language field', () => {
+      const container = document.body.appendChild(
+        document.createElement('div'),
+      );
+      // Try to inject onload attribute
+      container.innerHTML = normalizeHTML(
+        `<pre data-language="javascript&quot; onload=&quot;alert(1)"><br></pre>`,
+      );
+      const quill = new Quill(container, {
+        modules: {
+          syntax: {
+            hljs,
+            interval: HIGHLIGHT_INTERVAL,
+          },
+        },
+        registry: createRegistry([
+          CodeToken,
+          CodeBlock,
+          Quill.import('formats/code-block-container'),
+        ]),
+      });
+      const html = quill.getSemanticHTML();
+
+      // Should escape and not create executable code
+      expect(html).not.toContain('" onload="');
+      expect(html).toContain('&quot;');
+    });
+
+    test('handles normal language attributes safely', () => {
+      const quill = createQuill();
+      const html = quill.getSemanticHTML();
+
+      // Should contain properly formatted language attribute
+      expect(html).toContain('data-language="javascript"');
+      expect(html).toContain('<pre');
+      expect(html).toContain('</pre>');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Porting security fix from https://github.com/slab/quill/pull/4774 — the original maintainers of slab/quill have not merged this fix for several months, leaving users vulnerable.

This PR fixes **multiple XSS vulnerabilities** in Quill's `getSemanticHTML()` / `getHTML()` methods caused by insufficient HTML escaping and sanitization in the HTML export feature.

## Vulnerabilities Fixed

| # | Component | Severity | Status |
|---|-----------|----------|--------|
| 1 | Image blot missing `html()` method — event handler injection | 🔴 Critical | ✅ Fixed |
| 2 | Formula blot — unescaped user-controlled values | 🔴 Critical | ✅ Fixed |
| 3 | Video blot — unescaped video URLs | 🔴 Critical | ✅ Fixed |
| 4 | Link blot — missing `html()` method, protocol injection after DOM manipulation | 🔴 Critical | ✅ Fixed |
| 5 | Syntax module — unescaped `data-language` attribute | 🟠 High | ✅ Fixed |
| 6 | Editor `convertHTML()` — unsafe `outerHTML.split()` pattern | 🟡 Medium | ✅ Fixed |
| 7 | Snow theme tooltip — unsanitized link preview | 🟢 Low | ✅ Fixed |

## Changes

- `src/formats/formula.ts` — Escape formula values with `escapeText()`
- `src/formats/video.ts` — Escape video URLs with `escapeText()`
- `src/formats/image.ts` — Added `html()` method with attribute whitelisting and escaping
- `src/formats/link.ts` — Added `html()` method to re-sanitize href on export
- `src/modules/syntax.ts` — Escape `data-language` attribute value
- `src/core/editor.ts` — Replace unsafe `outerHTML.split()` with safe attribute reconstruction
- `src/themes/snow.ts` — Re-sanitize link preview before display

## Backwards Compatibility

✅ Fully backwards compatible — no API changes, no Delta format changes. Only affects HTML output (now properly escaped).