### PR TITLE
Support null theme in React editor

### DIFF
--- a/packages/quill-next-react/README.md
+++ b/packages/quill-next-react/README.md
@@ -60,6 +60,28 @@ function App() {
 
 ```
 
+### Use custom styles without a theme
+
+Pass `theme: null` to use Quill's core theme without loading the Snow, Bubble,
+or Next theme stylesheet. This is useful when the application provides all
+editor styles itself.
+
+```tsx
+import QuillEditor from 'quill-next-react';
+import 'quill-next/dist/quill.core.css';
+import './editor.scss';
+
+function App() {
+  return (
+    <QuillEditor
+      config={{ theme: null }}
+    />
+  );
+}
+```
+
+The core stylesheet is optional if the application supplies equivalent styles.
+
 ## Contributing
 
 Contributions are welcome! Please feel free to submit issues or pull requests.

--- a/packages/quill-next-react/src/editor-theme.spec.ts
+++ b/packages/quill-next-react/src/editor-theme.spec.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { resolveEditorTheme } from "./editor-theme";
+
+describe("resolveEditorTheme", () => {
+  it.each([
+    {
+      input: undefined,
+      expected: "next",
+    },
+    {
+      input: null,
+      expected: null,
+    },
+    {
+      input: "bubble",
+      expected: "bubble",
+    },
+  ])("resolves $input to $expected", ({ input, expected }) => {
+    expect(resolveEditorTheme(input)).toBe(expected);
+  });
+});

--- a/packages/quill-next-react/src/editor-theme.ts
+++ b/packages/quill-next-react/src/editor-theme.ts
@@ -1,0 +1,9 @@
+import type { QuillOptions } from "quill-next";
+
+const DEFAULT_EDITOR_THEME = "next";
+
+export function resolveEditorTheme(
+  theme: QuillOptions["theme"],
+): QuillOptions["theme"] {
+  return theme === undefined ? DEFAULT_EDITOR_THEME : theme;
+}

--- a/packages/quill-next-react/src/editor.component.tsx
+++ b/packages/quill-next-react/src/editor.component.tsx
@@ -7,6 +7,7 @@ import { ForkedRegistry } from "./forked-registry";
 import { EditorChangeHandler } from './types/editor-change-handler.type';
 import { NextTheme } from './next-theme';
 import { NextKeyboard } from "./modules/next-keyboard";
+import { resolveEditorTheme } from "./editor-theme";
 
 export interface IQuillEditorProps {
   defaultValue?: Delta;
@@ -52,7 +53,7 @@ function makeQuillWithBlots(container: HTMLElement, options: QuillOptions, blots
   return quill;
 }
 
-async function loadTheme(theme: string): Promise<void> {
+async function loadTheme(theme: QuillOptions["theme"]): Promise<void> {
   const insertTheme = (theme: string, content: string): void => {
     let styleElement: HTMLStyleElement | null = null;
     const existingStyleElement = document.head.querySelectorAll(`style[data-quill-theme="${theme}"]`);
@@ -100,13 +101,10 @@ const QuillEditor = (props: IQuillEditorProps): React.ReactNode => {
   const [themeLoaded, setThemeLoaded] = useState(false);
 
   useEffect(() => {
-    let theme = config?.theme;
-
-    if (!theme) {
-      theme = 'next';
-    }
+    const theme = resolveEditorTheme(config?.theme);
 
     let cancel = false;
+    setThemeLoaded(false);
     loadTheme(theme)
       .then(() => {
         if (cancel) {
@@ -133,12 +131,9 @@ const QuillEditor = (props: IQuillEditorProps): React.ReactNode => {
 
     const quillOptions: QuillOptions = {
       ...config,
+      theme: resolveEditorTheme(config?.theme),
       registry: forkedRegistry,
     };
-
-    if (!quillOptions.theme) {
-      quillOptions.theme = 'next';
-    }
 
     const quill = makeQuillWithBlots(
       containerRef.current!,

--- a/packages/quill/src/core/quill.ts
+++ b/packages/quill/src/core/quill.ts
@@ -37,7 +37,7 @@ Parchment.ParentBlot.uiClass = 'ql-ui';
  * Options for initializing a Quill instance
  */
 export interface QuillOptions {
-  theme?: string;
+  theme?: string | null;
   debug?: DebugLevel | boolean;
   registry?: Parchment.Registry;
   /**

--- a/packages/quill/test/unit/core/quill.spec.ts
+++ b/packages/quill/test/unit/core/quill.spec.ts
@@ -753,7 +753,6 @@ describe('Quill', () => {
 
       test('for null', () => {
         const config = expandConfig(`#${testContainerId}`, {
-          // @ts-expect-error
           theme: null,
         });
         expect(config.theme).toEqual(Theme);


### PR DESCRIPTION
## What changed

- allow `null` in the core `QuillOptions.theme` type
- preserve an explicit `theme: null` in `quill-next-react` instead of replacing it with the Next theme
- skip Snow, Bubble, and Next stylesheet injection when no theme is selected
- document custom SCSS styling with optional core CSS
- add regression coverage for default, null, and named theme resolution

## Why

Quill core already treats a falsy theme as the core theme at runtime, but the type excluded `null` and the React wrapper replaced it with `next`. Applications that own their editor styles could not opt out of automatic theme CSS.

## Impact

Existing consumers that omit `theme` still receive the Next theme. Consumers can now pass `config={{ theme: null }}` and provide their own styles.

## Validation

- `pnpm --filter quill-next run lint:tsc`
- `pnpm build:quill`
- `pnpm --filter quill-next-react run build`
- `pnpm --filter quill-next-react exec vitest run` — 9 tests passed
- focused Quill Chromium unit suite — 114 tests passed
- ESLint passed for both `quill-next` and `quill-next-react`
