### PR TITLE
Add preserveWhitespace option to getSemanticHTML

### DIFF
--- a/packages/quill/src/core.ts
+++ b/packages/quill/src/core.ts
@@ -5,6 +5,7 @@ import type {
   EmitterSource,
   ExpandedQuillOptions,
   QuillOptions,
+  SemanticHTMLOptions,
 } from './core/quill.js';
 
 import Block, { BlockEmbed } from './blots/block.js';
@@ -33,6 +34,7 @@ export type {
   EmitterSource,
   ExpandedQuillOptions,
   QuillOptions,
+  SemanticHTMLOptions,
 };
 export { default as Theme } from './core/theme.js';
 

--- a/packages/quill/src/core/editor.ts
+++ b/packages/quill/src/core/editor.ts
@@ -16,6 +16,14 @@ type SelectionInfo = {
   oldRange: Range;
 };
 
+export type SemanticHTMLOptions = {
+  preserveWhitespace?: boolean;
+};
+
+const defaultSemanticHTMLOptions: SemanticHTMLOptions = {
+  preserveWhitespace: false,
+} as const;
+
 class Editor {
   scroll: Scroll;
   delta: Delta;
@@ -195,15 +203,20 @@ class Editor {
     return { ...lineFormats, ...leafFormats };
   }
 
-  getHTML(index: number, length: number): string {
+  getHTML(
+    index: number,
+    length: number,
+    options?: SemanticHTMLOptions,
+  ): string {
+    const finalOptions = { ...defaultSemanticHTMLOptions, ...options };
     const [line, lineOffset] = this.scroll.line(index);
     if (line) {
       const lineLength = line.length();
       const isWithinLine = line.length() >= lineOffset + length;
       if (isWithinLine && !(lineOffset === 0 && length === lineLength)) {
-        return convertHTML(line, lineOffset, length, true);
+        return convertHTML(line, lineOffset, length, finalOptions, true);
       }
-      return convertHTML(this.scroll, index, length, true);
+      return convertHTML(this.scroll, index, length, finalOptions, true);
     }
     return '';
   }
@@ -328,13 +341,14 @@ function convertListHTML(
   items: ListItem[],
   lastIndent: number,
   types: string[],
+  options: SemanticHTMLOptions,
 ): string {
   if (items.length === 0) {
     const [endTag] = getListType(types.pop());
     if (lastIndent <= 0) {
       return `</li></${endTag}>`;
     }
-    return `</li></${endTag}>${convertListHTML([], lastIndent - 1, types)}`;
+    return `</li></${endTag}>${convertListHTML([], lastIndent - 1, types, options)}`;
   }
   const [{ child, offset, length, indent, type }, ...rest] = items;
   const [tag, attribute] = getListType(type);
@@ -345,9 +359,10 @@ function convertListHTML(
         child,
         offset,
         length,
-      )}${convertListHTML(rest, indent, types)}`;
+        options,
+      )}${convertListHTML(rest, indent, types, options)}`;
     }
-    return `<${tag}><li>${convertListHTML(items, lastIndent + 1, types)}`;
+    return `<${tag}><li>${convertListHTML(items, lastIndent + 1, types, options)}`;
   }
   const previousType = types[types.length - 1];
   if (indent === lastIndent && type === previousType) {
@@ -355,16 +370,18 @@ function convertListHTML(
       child,
       offset,
       length,
-    )}${convertListHTML(rest, indent, types)}`;
+      options,
+    )}${convertListHTML(rest, indent, types, options)}`;
   }
   const [endTag] = getListType(types.pop());
-  return `</li></${endTag}>${convertListHTML(items, lastIndent - 1, types)}`;
+  return `</li></${endTag}>${convertListHTML(items, lastIndent - 1, types, options)}`;
 }
 
 function convertHTML(
   blot: Blot,
   index: number,
   length: number,
+  options: SemanticHTMLOptions,
   isRoot = false,
 ): string {
   if ('html' in blot && typeof blot.html === 'function') {
@@ -372,6 +389,7 @@ function convertHTML(
   }
   if (blot instanceof TextBlot) {
     const escapedText = escapeText(blot.value().slice(index, index + length));
+    if (options.preserveWhitespace) return escapedText;
     return escapedText.replaceAll(' ', '&nbsp;');
   }
   if (blot instanceof ParentBlot) {
@@ -391,11 +409,11 @@ function convertHTML(
           type: formats.list,
         });
       });
-      return convertListHTML(items, -1, []);
+      return convertListHTML(items, -1, [], options);
     }
     const parts: string[] = [];
     blot.children.forEachAt(index, length, (child, offset, childLength) => {
-      parts.push(convertHTML(child, offset, childLength));
+      parts.push(convertHTML(child, offset, childLength, options));
     });
     if (isRoot || blot.statics.blotName === 'list') {
       return parts.join('');

--- a/packages/quill/src/core/editor.ts
+++ b/packages/quill/src/core/editor.ts
@@ -17,12 +17,17 @@ type SelectionInfo = {
 };
 
 export type SemanticHTMLOptions = {
+  /**
+   * Keep regular spaces in the exported HTML instead of converting them to
+   * non-breaking spaces. Browsers may collapse consecutive regular spaces.
+   * @default false
+   */
   preserveWhitespace?: boolean;
 };
 
 const defaultSemanticHTMLOptions: SemanticHTMLOptions = {
   preserveWhitespace: false,
-} as const;
+};
 
 class Editor {
   scroll: Scroll;
@@ -385,7 +390,7 @@ function convertHTML(
   isRoot = false,
 ): string {
   if ('html' in blot && typeof blot.html === 'function') {
-    return blot.html(index, length);
+    return blot.html(index, length, options);
   }
   if (blot instanceof TextBlot) {
     const escapedText = escapeText(blot.value().slice(index, index + length));

--- a/packages/quill/src/core/quill.ts
+++ b/packages/quill/src/core/quill.ts
@@ -9,14 +9,14 @@ import type Clipboard from '../modules/clipboard.js';
 import type History from '../modules/history.js';
 import type Keyboard from '../modules/keyboard.js';
 import type Uploader from '../modules/uploader.js';
-import Editor from './editor.js';
+import Editor, { type SemanticHTMLOptions } from './editor.js';
 import Emitter, { ensureDocumentListeners } from './emitter.js';
 import type { EmitterSource } from './emitter.js';
 import instances from './instances.js';
 import logger from './logger.js';
 import type { DebugLevel } from './logger.js';
 import Module from './module.js';
-import Selection, { Range } from './selection.js';
+import Selection, { isRange, Range } from './selection.js';
 import type { Bounds } from './selection.js';
 import Composition from './composition.js';
 import Theme from './theme.js';
@@ -309,7 +309,6 @@ class Quill {
     length?: number | EmitterSource,
     source?: EmitterSource,
   ): Delta {
-    // @ts-expect-error
     [index, length, , source] = overload(index, length, source);
     return modify.call(
       this,
@@ -400,7 +399,6 @@ class Quill {
     [index, length, formats, source] = overload(
       index,
       length,
-      // @ts-expect-error
       name,
       value,
       source,
@@ -445,7 +443,6 @@ class Quill {
     let formats: Record<string, unknown>;
     // eslint-disable-next-line prefer-const
     [index, length, formats, source] = overload(
-      // @ts-expect-error
       index,
       length,
       name,
@@ -541,15 +538,45 @@ class Quill {
     return this.selection.getRange()[0];
   }
 
-  getSemanticHTML(range: Range): string;
-  getSemanticHTML(index?: number, length?: number): string;
-  getSemanticHTML(index: Range | number = 0, length?: number) {
-    if (typeof index === 'number') {
-      length = length ?? this.getLength() - index;
+  getSemanticHTML(options?: SemanticHTMLOptions): string;
+  getSemanticHTML(range: Range, options?: SemanticHTMLOptions): string;
+  getSemanticHTML(index: number, options?: SemanticHTMLOptions): string;
+  getSemanticHTML(
+    index: number,
+    length: number,
+    options?: SemanticHTMLOptions,
+  ): string;
+  getSemanticHTML(
+    indexOrRangeOrOptions?: Range | number | SemanticHTMLOptions,
+    lengthOrOptions?: number | SemanticHTMLOptions,
+    options?: SemanticHTMLOptions,
+  ) {
+    let finalIndex: number | Range = 0;
+    let finalLength: number | undefined = undefined;
+    let finalOptions: SemanticHTMLOptions = {};
+
+    if (indexOrRangeOrOptions === undefined) {
+      finalIndex = 0;
+      finalLength = this.getLength() - finalIndex;
+    } else if (isRange(indexOrRangeOrOptions)) {
+      finalIndex = indexOrRangeOrOptions as Range;
+      finalOptions = (lengthOrOptions as SemanticHTMLOptions) ?? {};
+    } else if (typeof indexOrRangeOrOptions === 'number') {
+      finalIndex = indexOrRangeOrOptions;
+      if (typeof lengthOrOptions === 'number') {
+        finalLength = lengthOrOptions;
+        finalOptions = options ?? {};
+      } else {
+        finalLength = this.getLength() - finalIndex;
+        finalOptions = (lengthOrOptions as SemanticHTMLOptions) ?? {};
+      }
+    } else {
+      finalIndex = 0;
+      finalLength = this.getLength() - finalIndex;
+      finalOptions = indexOrRangeOrOptions;
     }
-    // @ts-expect-error
-    [index, length] = overload(index, length);
-    return this.editor.getHTML(index, length);
+    [finalIndex, finalLength] = overload(finalIndex, finalLength);
+    return this.editor.getHTML(finalIndex, finalLength, finalOptions);
   }
 
   getText(range?: Range): string;
@@ -558,7 +585,6 @@ class Quill {
     if (typeof index === 'number') {
       length = length ?? this.getLength() - index;
     }
-    // @ts-expect-error
     [index, length] = overload(index, length);
     return this.editor.getText(index, length);
   }
@@ -605,8 +631,6 @@ class Quill {
     source?: EmitterSource,
   ): Delta {
     let formats: Record<string, unknown>;
-    // eslint-disable-next-line prefer-const
-    // @ts-expect-error
     [index, , formats, source] = overload(index, 0, name, value, source);
     return modify.call(
       this,
@@ -732,7 +756,6 @@ class Quill {
       // @ts-expect-error https://github.com/microsoft/TypeScript/issues/22609
       this.selection.setRange(null, length || Quill.sources.API);
     } else {
-      // @ts-expect-error
       [index, length, , source] = overload(index, length, source);
       this.selection.setRange(new Range(Math.max(0, index), length), source);
       if (source !== Emitter.sources.SILENT) {
@@ -956,6 +979,13 @@ function overload(
 function overload(
   range: Range,
   format: Record<string, unknown>,
+  source?: EmitterSource,
+): NormalizedIndexLength;
+function overload(
+  index: Range | number,
+  length?: number | string | Record<string, unknown> | EmitterSource,
+  name?: string | unknown | Record<string, unknown> | EmitterSource,
+  value?: unknown | EmitterSource,
   source?: EmitterSource,
 ): NormalizedIndexLength;
 function overload(

--- a/packages/quill/src/core/quill.ts
+++ b/packages/quill/src/core/quill.ts
@@ -16,7 +16,7 @@ import instances from './instances.js';
 import logger from './logger.js';
 import type { DebugLevel } from './logger.js';
 import Module from './module.js';
-import Selection, { isRange, Range } from './selection.js';
+import Selection, { Range } from './selection.js';
 import type { Bounds } from './selection.js';
 import Composition from './composition.js';
 import Theme from './theme.js';
@@ -309,6 +309,7 @@ class Quill {
     length?: number | EmitterSource,
     source?: EmitterSource,
   ): Delta {
+    // @ts-expect-error
     [index, length, , source] = overload(index, length, source);
     return modify.call(
       this,
@@ -399,6 +400,7 @@ class Quill {
     [index, length, formats, source] = overload(
       index,
       length,
+      // @ts-expect-error
       name,
       value,
       source,
@@ -443,6 +445,7 @@ class Quill {
     let formats: Record<string, unknown>;
     // eslint-disable-next-line prefer-const
     [index, length, formats, source] = overload(
+      // @ts-expect-error
       index,
       length,
       name,
@@ -541,9 +544,10 @@ class Quill {
   getSemanticHTML(options?: SemanticHTMLOptions): string;
   getSemanticHTML(range: Range, options?: SemanticHTMLOptions): string;
   getSemanticHTML(index: number, options?: SemanticHTMLOptions): string;
+  getSemanticHTML(index?: number, length?: number): string;
   getSemanticHTML(
-    index: number,
-    length: number,
+    index: number | undefined,
+    length: number | undefined,
     options?: SemanticHTMLOptions,
   ): string;
   getSemanticHTML(
@@ -551,32 +555,41 @@ class Quill {
     lengthOrOptions?: number | SemanticHTMLOptions,
     options?: SemanticHTMLOptions,
   ) {
-    let finalIndex: number | Range = 0;
-    let finalLength: number | undefined = undefined;
-    let finalOptions: SemanticHTMLOptions = {};
-
     if (indexOrRangeOrOptions === undefined) {
-      finalIndex = 0;
-      finalLength = this.getLength() - finalIndex;
-    } else if (isRange(indexOrRangeOrOptions)) {
-      finalIndex = indexOrRangeOrOptions as Range;
-      finalOptions = (lengthOrOptions as SemanticHTMLOptions) ?? {};
-    } else if (typeof indexOrRangeOrOptions === 'number') {
-      finalIndex = indexOrRangeOrOptions;
-      if (typeof lengthOrOptions === 'number') {
-        finalLength = lengthOrOptions;
-        finalOptions = options ?? {};
-      } else {
-        finalLength = this.getLength() - finalIndex;
-        finalOptions = (lengthOrOptions as SemanticHTMLOptions) ?? {};
-      }
-    } else {
-      finalIndex = 0;
-      finalLength = this.getLength() - finalIndex;
-      finalOptions = indexOrRangeOrOptions;
+      const length =
+        typeof lengthOrOptions === 'number'
+          ? lengthOrOptions
+          : this.getLength();
+      const finalOptions =
+        options ??
+        (typeof lengthOrOptions === 'number' ? undefined : lengthOrOptions);
+      return this.editor.getHTML(0, length, finalOptions);
     }
-    [finalIndex, finalLength] = overload(finalIndex, finalLength);
-    return this.editor.getHTML(finalIndex, finalLength, finalOptions);
+
+    if (typeof indexOrRangeOrOptions === 'number') {
+      const index = indexOrRangeOrOptions;
+      const length =
+        typeof lengthOrOptions === 'number'
+          ? lengthOrOptions
+          : this.getLength() - index;
+      const finalOptions =
+        options ??
+        (typeof lengthOrOptions === 'number' ? undefined : lengthOrOptions);
+      return this.editor.getHTML(index, length, finalOptions);
+    }
+
+    if (isRange(indexOrRangeOrOptions)) {
+      const finalOptions =
+        options ??
+        (typeof lengthOrOptions === 'number' ? undefined : lengthOrOptions);
+      return this.editor.getHTML(
+        indexOrRangeOrOptions.index,
+        indexOrRangeOrOptions.length,
+        finalOptions,
+      );
+    }
+
+    return this.editor.getHTML(0, this.getLength(), indexOrRangeOrOptions);
   }
 
   getText(range?: Range): string;
@@ -585,6 +598,7 @@ class Quill {
     if (typeof index === 'number') {
       length = length ?? this.getLength() - index;
     }
+    // @ts-expect-error
     [index, length] = overload(index, length);
     return this.editor.getText(index, length);
   }
@@ -631,6 +645,8 @@ class Quill {
     source?: EmitterSource,
   ): Delta {
     let formats: Record<string, unknown>;
+    // eslint-disable-next-line prefer-const
+    // @ts-expect-error
     [index, , formats, source] = overload(index, 0, name, value, source);
     return modify.call(
       this,
@@ -756,6 +772,7 @@ class Quill {
       // @ts-expect-error https://github.com/microsoft/TypeScript/issues/22609
       this.selection.setRange(null, length || Quill.sources.API);
     } else {
+      // @ts-expect-error
       [index, length, , source] = overload(index, length, source);
       this.selection.setRange(new Range(Math.max(0, index), length), source);
       if (source !== Emitter.sources.SILENT) {
@@ -987,13 +1004,6 @@ function overload(
   name?: string | unknown | Record<string, unknown> | EmitterSource,
   value?: unknown | EmitterSource,
   source?: EmitterSource,
-): NormalizedIndexLength;
-function overload(
-  index: Range | number,
-  length?: number | string | Record<string, unknown> | EmitterSource,
-  name?: string | unknown | Record<string, unknown> | EmitterSource,
-  value?: unknown | EmitterSource,
-  source?: EmitterSource,
 ): NormalizedIndexLength {
   let formats: Record<string, unknown> = {};
   // @ts-expect-error
@@ -1079,7 +1089,18 @@ function shiftRange(
   return new Range(start, end - start);
 }
 
-export type { Bounds, DebugLevel, EmitterSource };
+function isRange(value: unknown): value is Range {
+  return (
+    value != null &&
+    typeof value === 'object' &&
+    'index' in value &&
+    typeof value.index === 'number' &&
+    'length' in value &&
+    typeof value.length === 'number'
+  );
+}
+
+export type { Bounds, DebugLevel, EmitterSource, SemanticHTMLOptions };
 export { Parchment, Range };
 
 export { globalRegistry, expandConfig, overload, Quill as default };

--- a/packages/quill/src/core/selection.ts
+++ b/packages/quill/src/core/selection.ts
@@ -35,6 +35,17 @@ export class Range {
   ) {}
 }
 
+export function isRange(value: any): value is Range {
+  return (
+    value &&
+    typeof value === 'object' &&
+    'index' in value &&
+    typeof value.index === 'number' &&
+    'length' in value &&
+    typeof value.length === 'number'
+  );
+}
+
 class Selection {
   scroll: Scroll;
   emitter: Emitter;

--- a/packages/quill/src/core/selection.ts
+++ b/packages/quill/src/core/selection.ts
@@ -35,17 +35,6 @@ export class Range {
   ) {}
 }
 
-export function isRange(value: any): value is Range {
-  return (
-    value &&
-    typeof value === 'object' &&
-    'index' in value &&
-    typeof value.index === 'number' &&
-    'length' in value &&
-    typeof value.length === 'number'
-  );
-}
-
 class Selection {
   scroll: Scroll;
   emitter: Emitter;

--- a/packages/quill/src/formats/link.ts
+++ b/packages/quill/src/formats/link.ts
@@ -1,5 +1,6 @@
 import Inline from '../blots/inline.js';
 import { escapeText } from '../blots/text.js';
+import type { SemanticHTMLOptions } from '../core/editor.js';
 
 class Link extends Inline {
   static blotName = 'link';
@@ -32,7 +33,7 @@ class Link extends Inline {
     }
   }
 
-  html(index: number, length: number) {
+  html(index: number, length: number, options?: SemanticHTMLOptions) {
     const LinkClass = this.constructor as typeof Link;
     const href = LinkClass.sanitize(this.domNode.getAttribute('href') || '');
     const rel = this.domNode.getAttribute('rel');
@@ -45,12 +46,15 @@ class Link extends Inline {
     const parts: string[] = [];
     this.children.forEachAt(index, length, (child, offset, childLength) => {
       if ('html' in child && typeof child.html === 'function') {
-        parts.push(child.html(offset, childLength));
+        parts.push(child.html(offset, childLength, options));
       } else if ('value' in child && typeof child.value === 'function') {
+        const escapedText = escapeText(
+          (child.value() as string).slice(offset, offset + childLength),
+        );
         parts.push(
-          escapeText(
-            (child.value() as string).slice(offset, offset + childLength),
-          ).replaceAll(' ', '&nbsp;'),
+          options?.preserveWhitespace
+            ? escapedText
+            : escapedText.replaceAll(' ', '&nbsp;'),
         );
       } else {
         parts.push((child.domNode as Element).outerHTML);

--- a/packages/quill/src/quill.ts
+++ b/packages/quill/src/quill.ts
@@ -5,6 +5,7 @@ import type {
   EmitterSource,
   ExpandedQuillOptions,
   QuillOptions,
+  SemanticHTMLOptions,
 } from './core.js';
 
 import { AlignClass, AlignStyle } from './formats/align.js';
@@ -139,6 +140,7 @@ export type {
   EmitterSource,
   ExpandedQuillOptions,
   QuillOptions,
+  SemanticHTMLOptions,
   KeyboardOptions,
   BindingObject,
   Binding,

--- a/packages/quill/test/types/quill.test-d.ts
+++ b/packages/quill/test/types/quill.test-d.ts
@@ -1,6 +1,11 @@
 import { assertType, expectTypeOf } from 'vitest';
 import Quill, { Delta } from '../../src/quill.js';
-import type { EmitterSource, Parchment, Range } from '../../src/quill.js';
+import type {
+  EmitterSource,
+  Parchment,
+  Range,
+  SemanticHTMLOptions,
+} from '../../src/quill.js';
 import type { default as Block, BlockEmbed } from '../../src/blots/block.js';
 import SnowTheme from '../../src/themes/snow.js';
 import { LeafBlot } from 'parchment';
@@ -54,9 +59,18 @@ const quill = new Quill('#editor');
 }
 
 {
+  const options: SemanticHTMLOptions = { preserveWhitespace: true };
   assertType<string>(quill.getSemanticHTML());
+  assertType<string>(quill.getSemanticHTML(options));
   assertType<string>(quill.getSemanticHTML(1));
+  assertType<string>(quill.getSemanticHTML(1, options));
   assertType<string>(quill.getSemanticHTML(1, 2));
+  assertType<string>(quill.getSemanticHTML(undefined, undefined));
+  assertType<string>(quill.getSemanticHTML(1, 2, options));
+  assertType<string>(quill.getSemanticHTML(1, undefined, options));
+  assertType<string>(quill.getSemanticHTML({ index: 1, length: 2 }, options));
+  assertType<string>(quill.getSemanticHTML(undefined, 2, options));
+  assertType<string>(quill.getSemanticHTML(undefined, undefined, options));
 }
 
 {

--- a/packages/quill/test/unit/core/editor.spec.ts
+++ b/packages/quill/test/unit/core/editor.spec.ts
@@ -1412,6 +1412,18 @@ describe('Editor', () => {
       expect(editor.getHTML(0, 5)).toEqual('<ul><li>Test</li></ul>');
     });
 
+    test('option preserveWhitespace is disabled (DEFAULT)', () => {
+      const editor = createEditor('<p>This is Quill</p>');
+      expect(editor.getHTML(0, 14)).toEqual('<p>This&nbsp;is&nbsp;Quill</p>');
+    });
+
+    test('option preserveWhitespace is enabled', () => {
+      const editor = createEditor('<p>This is Quill</p>');
+      expect(editor.getHTML(0, 14, { preserveWhitespace: true })).toEqual(
+        '<p>This is Quill</p>',
+      );
+    });
+
     test('across lines', () => {
       const editor = createEditor(
         '<h1 class="ql-align-center">Header</h1><p>Text</p><blockquote>Quote</blockquote>',

--- a/packages/quill/test/unit/core/editor.spec.ts
+++ b/packages/quill/test/unit/core/editor.spec.ts
@@ -1412,15 +1412,43 @@ describe('Editor', () => {
       expect(editor.getHTML(0, 5)).toEqual('<ul><li>Test</li></ul>');
     });
 
-    test('option preserveWhitespace is disabled (DEFAULT)', () => {
+    test('converts spaces to non-breaking spaces by default', () => {
       const editor = createEditor('<p>This is Quill</p>');
       expect(editor.getHTML(0, 14)).toEqual('<p>This&nbsp;is&nbsp;Quill</p>');
+      expect(editor.getHTML(0, 14, { preserveWhitespace: false })).toEqual(
+        '<p>This&nbsp;is&nbsp;Quill</p>',
+      );
     });
 
-    test('option preserveWhitespace is enabled', () => {
+    test('preserves regular spaces when enabled', () => {
       const editor = createEditor('<p>This is Quill</p>');
       expect(editor.getHTML(0, 14, { preserveWhitespace: true })).toEqual(
         '<p>This is Quill</p>',
+      );
+    });
+
+    test('preserves consecutive spaces without bypassing text escaping', () => {
+      const editor = createEditor(
+        new Delta().insert('  A < B & C  ', { bold: true }).insert('\n'),
+      );
+      expect(editor.getHTML(0, 13, { preserveWhitespace: true })).toEqual(
+        '<strong>  A &lt; B &amp; C  </strong>',
+      );
+    });
+
+    test('preserves spaces across inline formats and lists', () => {
+      const inlineEditor = createEditor(
+        '<p><strong>One two</strong> <em>three four</em></p>',
+      );
+      expect(inlineEditor.getHTML(0, 19, { preserveWhitespace: true })).toEqual(
+        '<p><strong>One two</strong> <em>three four</em></p>',
+      );
+
+      const listEditor = createEditor(
+        '<ol><li>One two</li><li>Three four</li></ol>',
+      );
+      expect(listEditor.getHTML(0, 19, { preserveWhitespace: true })).toEqual(
+        '<ol><li>One two</li><li>Three four</li></ol>',
       );
     });
 

--- a/packages/quill/test/unit/core/quill.spec.ts
+++ b/packages/quill/test/unit/core/quill.spec.ts
@@ -605,9 +605,33 @@ describe('Quill', () => {
 
     test('works with range', () => {
       const quill = new Quill(createContainer('<h1>Welcome</h1>'));
-      expect(quill.getText({ index: 1, length: 2 })).toMatchInlineSnapshot(
-        '"el"',
-      );
+      expect(
+        quill.getSemanticHTML({ index: 1, length: 2 }),
+      ).toMatchInlineSnapshot('"el"');
+    });
+
+    test('works with only options', () => {
+      const quill = new Quill(createContainer('<h1>Welcome to quill</h1>'));
+      expect(quill.getSemanticHTML({ preserveWhitespace: true }))
+        .toMatchInlineSnapshot(`
+        "<h1>Welcome to quill</h1>"
+      `);
+    });
+
+    test('works with index and options', () => {
+      const quill = new Quill(createContainer('<h1>Welcome to quill</h1>'));
+      expect(quill.getSemanticHTML(0, { preserveWhitespace: true }))
+        .toMatchInlineSnapshot(`
+        "<h1>Welcome to quill</h1>"
+      `);
+    });
+
+    test('works with index, length and options', () => {
+      const quill = new Quill(createContainer('<h1>Welcome to quill</h1>'));
+      expect(quill.getSemanticHTML(0, 10, { preserveWhitespace: true }))
+        .toMatchInlineSnapshot(`
+        "Welcome to"
+      `);
     });
   });
 
@@ -1148,7 +1172,6 @@ describe('Quill', () => {
     });
 
     test('(range:range, dummy:number)', () => {
-      // @ts-expect-error
       const [index, length, formats, source] = overload(new Range(10, 1), 0);
       expect(index).toBe(10);
       expect(length).toBe(1);
@@ -1157,7 +1180,6 @@ describe('Quill', () => {
     });
 
     test('(range:range, dummy:number, format:string, value:boolean)', () => {
-      // @ts-expect-error
       const [index, length, formats, source] = overload(
         new Range(10, 1),
         0,
@@ -1171,7 +1193,6 @@ describe('Quill', () => {
     });
 
     test('(range:range, dummy:number, format:object, source:string)', () => {
-      // @ts-expect-error
       const [index, length, formats, source] = overload(
         new Range(10, 1),
         0,

--- a/packages/quill/test/unit/core/quill.spec.ts
+++ b/packages/quill/test/unit/core/quill.spec.ts
@@ -605,33 +605,9 @@ describe('Quill', () => {
 
     test('works with range', () => {
       const quill = new Quill(createContainer('<h1>Welcome</h1>'));
-      expect(
-        quill.getSemanticHTML({ index: 1, length: 2 }),
-      ).toMatchInlineSnapshot('"el"');
-    });
-
-    test('works with only options', () => {
-      const quill = new Quill(createContainer('<h1>Welcome to quill</h1>'));
-      expect(quill.getSemanticHTML({ preserveWhitespace: true }))
-        .toMatchInlineSnapshot(`
-        "<h1>Welcome to quill</h1>"
-      `);
-    });
-
-    test('works with index and options', () => {
-      const quill = new Quill(createContainer('<h1>Welcome to quill</h1>'));
-      expect(quill.getSemanticHTML(0, { preserveWhitespace: true }))
-        .toMatchInlineSnapshot(`
-        "<h1>Welcome to quill</h1>"
-      `);
-    });
-
-    test('works with index, length and options', () => {
-      const quill = new Quill(createContainer('<h1>Welcome to quill</h1>'));
-      expect(quill.getSemanticHTML(0, 10, { preserveWhitespace: true }))
-        .toMatchInlineSnapshot(`
-        "Welcome to"
-      `);
+      expect(quill.getText({ index: 1, length: 2 })).toMatchInlineSnapshot(
+        '"el"',
+      );
     });
   });
 
@@ -657,11 +633,61 @@ describe('Quill', () => {
       `);
     });
 
+    test('keeps the existing space conversion by default', () => {
+      const quill = new Quill(createContainer('<h1>Welcome home</h1>'));
+      expect(quill.getSemanticHTML()).toBe('<h1>Welcome&nbsp;home</h1>');
+    });
+
     test('works with range', () => {
       const quill = new Quill(createContainer('<h1>Welcome</h1>'));
-      expect(quill.getText({ index: 1, length: 2 })).toMatchInlineSnapshot(
-        '"el"',
+      expect(
+        quill.getSemanticHTML({ index: 1, length: 2 }),
+      ).toMatchInlineSnapshot('"el"');
+    });
+
+    test('works with only options', () => {
+      const quill = new Quill(createContainer('<h1>Welcome to quill</h1>'));
+      expect(quill.getSemanticHTML({ preserveWhitespace: true })).toBe(
+        '<h1>Welcome to quill</h1>',
       );
+    });
+
+    test('works with range and options', () => {
+      const quill = new Quill(createContainer('<h1>Welcome to quill</h1>'));
+      expect(
+        quill.getSemanticHTML(
+          { index: 0, length: 10 },
+          { preserveWhitespace: true },
+        ),
+      ).toBe('Welcome to');
+    });
+
+    test('works with index and options', () => {
+      const quill = new Quill(createContainer('<h1>Welcome to quill</h1>'));
+      expect(quill.getSemanticHTML(0, { preserveWhitespace: true })).toBe(
+        '<h1>Welcome to quill</h1>',
+      );
+    });
+
+    test('works with index, length and options', () => {
+      const quill = new Quill(createContainer('<h1>Welcome to quill</h1>'));
+      expect(quill.getSemanticHTML(0, 10, { preserveWhitespace: true })).toBe(
+        'Welcome to',
+      );
+    });
+
+    test('works with an omitted index and explicit length', () => {
+      const quill = new Quill(createContainer('<h1>Welcome to quill</h1>'));
+      expect(
+        quill.getSemanticHTML(undefined, 10, { preserveWhitespace: true }),
+      ).toBe('Welcome to');
+    });
+
+    test('works with an omitted length and explicit options', () => {
+      const quill = new Quill(createContainer('<h1>Welcome to quill</h1>'));
+      expect(
+        quill.getSemanticHTML(0, undefined, { preserveWhitespace: true }),
+      ).toBe('<h1>Welcome to quill</h1>');
     });
   });
 
@@ -1172,6 +1198,7 @@ describe('Quill', () => {
     });
 
     test('(range:range, dummy:number)', () => {
+      // @ts-expect-error
       const [index, length, formats, source] = overload(new Range(10, 1), 0);
       expect(index).toBe(10);
       expect(length).toBe(1);
@@ -1180,6 +1207,7 @@ describe('Quill', () => {
     });
 
     test('(range:range, dummy:number, format:string, value:boolean)', () => {
+      // @ts-expect-error
       const [index, length, formats, source] = overload(
         new Range(10, 1),
         0,
@@ -1193,6 +1221,7 @@ describe('Quill', () => {
     });
 
     test('(range:range, dummy:number, format:object, source:string)', () => {
+      // @ts-expect-error
       const [index, length, formats, source] = overload(
         new Range(10, 1),
         0,

--- a/packages/quill/test/unit/formats/link.spec.ts
+++ b/packages/quill/test/unit/formats/link.spec.ts
@@ -203,4 +203,22 @@ describe('Link XSS Prevention (getSemanticHTML)', () => {
     expect(html).toContain('>click&nbsp;here</a>');
     expect(html).toContain('href="https://example.com"');
   });
+
+  test('preserves link text spaces without bypassing URL sanitization', () => {
+    const editor = new Editor(createScroll('<p>click here</p>'));
+    editor.formatText(0, 10, { link: 'https://example.com' });
+
+    const anchor = editor.scroll.domNode.querySelector('a')!;
+    anchor.setAttribute('href', 'javascript:alert(document.cookie)'); // eslint-disable-line no-script-url
+
+    const defaultHTML = editor.getHTML(0, 10);
+    const preservedHTML = editor.getHTML(0, 10, {
+      preserveWhitespace: true,
+    });
+
+    expect(defaultHTML).toContain('>click&nbsp;here</a>');
+    expect(preservedHTML).toContain('>click here</a>');
+    expect(preservedHTML).not.toContain('javascript:');
+    expect(preservedHTML).toContain('href="about:blank"');
+  });
 });

--- a/packages/website/content/docs/api.mdx
+++ b/packages/website/content/docs/api.mdx
@@ -116,16 +116,28 @@ This method is useful for exporting the contents of the editor in a format that 
 
 The `length` parameter defaults to the length of the remaining document.
 
+The optional `preserveWhitespace` setting controls how regular spaces are
+serialized. By default, spaces are converted to `&nbsp;` so consecutive spaces
+survive HTML rendering. Set `preserveWhitespace` to `true` to export regular,
+wrappable spaces instead. Browsers may collapse consecutive regular spaces.
+
 **Methods**
 
 ```typescript
-getSemanticHTML(index: number = 0, length: number = remaining): string
+getSemanticHTML(options?: SemanticHTMLOptions): string
+getSemanticHTML(range: Range, options?: SemanticHTMLOptions): string
+getSemanticHTML(index: number = 0, options?: SemanticHTMLOptions): string
+getSemanticHTML(index: number = 0, length: number = remaining, options?: SemanticHTMLOptions): string
 ```
 
 **Examples**
 
 ```typescript
 const html = quill.getSemanticHTML(0, 10);
+
+const wrappableHTML = quill.getSemanticHTML({
+  preserveWhitespace: true,
+});
 ```
 
 ### insertEmbed


### PR DESCRIPTION
## Summary

- add a `preserveWhitespace` option to `getSemanticHTML()`
- support options-only, range, index, and index/length call forms while preserving the existing overloads
- keep the default `space -> &nbsp;` behavior for backward compatibility
- propagate the option through lists and custom HTML blots, including links
- preserve the existing link URL sanitization and semantic HTML XSS protections
- publicly export `SemanticHTMLOptions` and document the API
- restore the lost `getText(range)` coverage and add whitespace, escaping, link, list, compatibility, and type tests

This supersedes #49 and is based on the implementation proposed by @MaciejDabek in slab/quill#4598.

## Why

Since Quill 2.0.3, `getSemanticHTML()` converts every regular space to `&nbsp;`. That preserves consecutive spaces but also prevents normal line wrapping and causes problems for database, PDF, email, and downstream HTML consumers.

This change provides an opt-in way to export regular, wrappable spaces without changing the existing default or the internal clipboard behavior. Browsers may still collapse consecutive regular spaces when the option is enabled.

## Validation

- `pnpm --filter quill-next run test:unit`: 36 files, 616 tests passed; no type errors
- `pnpm --filter quill-next run lint`
- `pnpm run build:quill`
- `pnpm --filter quill-next-react run build`
- `pnpm --filter website run build`
