### PR TITLE
fix: serialize registered formula and video values

### DIFF
--- a/packages/quill/src/formats/formula.ts
+++ b/packages/quill/src/formats/formula.ts
@@ -30,7 +30,8 @@ class Formula extends Embed {
   domNode: HTMLElement;
 
   html() {
-    const formula = Formula.value(this.domNode) || '';
+    const FormulaClass = this.constructor as typeof Formula;
+    const formula = FormulaClass.value(this.domNode) || '';
     return `<span>${escapeText(formula)}</span>`;
   }
 }

--- a/packages/quill/src/formats/video.ts
+++ b/packages/quill/src/formats/video.ts
@@ -52,7 +52,8 @@ class Video extends BlockEmbed {
   }
 
   html() {
-    const video = Video.sanitize(Video.value(this.domNode) || '');
+    const VideoClass = this.constructor as typeof Video;
+    const video = VideoClass.sanitize(VideoClass.value(this.domNode) || '');
     return `<a href="${escapeText(video)}">${escapeText(video)}</a>`;
   }
 }

--- a/packages/quill/test/unit/formats/formula.spec.ts
+++ b/packages/quill/test/unit/formats/formula.spec.ts
@@ -9,6 +9,14 @@ import Formula from '../../../src/formats/formula.js';
 const createScroll = (html: string) =>
   baseCreateScroll(html, createRegistry([Formula]));
 
+class ReplacementFormula extends Formula {
+  static override blotName = 'formula';
+
+  static override value() {
+    return 'replacement <formula>';
+  }
+}
+
 describe('Formula', () => {
   // Mock KaTeX for tests
   beforeAll(() => {
@@ -114,6 +122,22 @@ describe('Formula', () => {
 
       // Should double-escape (correct behavior - user wanted literal text)
       expect(html).toContain('&amp;lt;script&amp;gt;');
+    });
+
+    test('serializes the value from a registered subclass', () => {
+      const scroll = baseCreateScroll(
+        '<p><br></p>',
+        createRegistry([ReplacementFormula]),
+      );
+      const editor = new Editor(scroll);
+      editor.insertEmbed(0, 'formula', 'original formula');
+
+      expect(editor.getContents(0, 2).ops[0]).toEqual({
+        insert: { formula: 'replacement <formula>' },
+      });
+      expect(editor.getHTML(0, 2)).toContain(
+        '<span>replacement &lt;formula&gt;</span>',
+      );
     });
   });
 });

--- a/packages/quill/test/unit/formats/video.spec.ts
+++ b/packages/quill/test/unit/formats/video.spec.ts
@@ -9,6 +9,14 @@ import Video from '../../../src/formats/video.js';
 const createScroll = (html: string) =>
   baseCreateScroll(html, createRegistry([Video]));
 
+class ReplacementVideo extends Video {
+  static override blotName = 'video';
+
+  static override value() {
+    return 'https://replacement.example/video';
+  }
+}
+
 describe('Video', () => {
   describe('XSS Prevention', () => {
     test('escapes HTML tags in video URL', () => {
@@ -92,6 +100,23 @@ describe('Video', () => {
 
       // Should create valid HTML even with empty URL
       expect(html).toContain('<a href=""></a>');
+    });
+
+    test('serializes the value from a registered subclass', () => {
+      const scroll = baseCreateScroll(
+        '<p><br></p>',
+        createRegistry([ReplacementVideo]),
+      );
+      const editor = new Editor(scroll);
+      editor.insertEmbed(0, 'video', 'https://original.example/video');
+
+      expect(editor.getContents(0, 2).ops[0]).toEqual({
+        insert: { video: 'https://replacement.example/video' },
+      });
+      expect(editor.getHTML(0, 2)).toContain(
+        '<a href="https://replacement.example/video">' +
+          'https://replacement.example/video</a>',
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary

- resolve formula and video HTML serialization through the registered blot subclass
- retain the existing HTML escaping and video URL sanitization
- add regressions proving Delta and semantic HTML use the same overridden value

## Problem

`Formula.html()` and `Video.html()` call static methods on the base classes. Applications can register subclasses under the same blot names, and Parchment correctly uses the subclass overrides for Delta values, but `getSemanticHTML()` bypasses those overrides and exports the original DOM attributes instead.

Resolving the class from each blot instance keeps semantic HTML consistent with the registered implementation.

## Validation

- `pnpm --filter quill-next exec vitest run --config test/unit/vitest.config.ts` — 36 files, 606 tests passed
- `pnpm --filter quill-next lint`
- `pnpm run build:quill`
- `pnpm --filter quill-next test:e2e` on Node 22 — 87 tests passed across Chrome, Firefox, and Safari